### PR TITLE
Minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: python
 python:
   - "3.5"
   - "3.6"
-  - "3.7"
 
 addons:
   apt:
@@ -23,7 +22,7 @@ env:
   - DISPLAY=:99 PATH=/usr/lib/chromium-browser:$PATH
 
 install:
-  - pip install .[prompt,vis]
+  - pip install -v .[prompt,vis]
   - pip install nose coverage
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 
 addons:
   apt:
@@ -22,7 +23,7 @@ env:
   - DISPLAY=:99 PATH=/usr/lib/chromium-browser:$PATH
 
 install:
-  - pip install -v .[prompt,vis]
+  - pip install .[prompt,vis]
   - pip install nose coverage
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ addons:
       - libffi-dev
       - uuid-dev
       - wget
-      - xdot
 
 env:
   - DISPLAY=:99 PATH=/usr/lib/chromium-browser:$PATH

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ where
     enables the game states viewer (available for generated games only). 
     To activate it, use the `--html-render` option when running the `tw-play` script, 
     and the current state of the game will be displayed in your browser.
+    
+    In order to use the `take_screenshot` or `visualize` functions in `textworld.render`,
+    you'll need to install either the [Chrome](https://sites.google.com/a/chromium.org/chromedriver/) 
+    or [Firefox](https://github.com/mozilla/geckodriver) webdriver (depending on whichever
+    browser you have installed). If you have Chrome already installed you can use the following command to 
+    install chromedriver: `pip install chromedriver_installer`.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ TextWorld requires __Python 3__ and only supports __Linux__ and __Mac__ systems 
 
 The following system libraries are required to install and run TextWorld:
 ```
-sudo apt-get -y install uuid-dev libffi-dev build-essential curl xdot gcc make python3-dev
+sudo apt-get -y install uuid-dev libffi-dev build-essential curl gcc make python3-dev
 ```
 as well as some Python libraries that can be installed separately using
 ```
@@ -42,11 +42,6 @@ where
     enables the game states viewer (available for generated games only). 
     To activate it, use the `--html-render` option when running the `tw-play` script, 
     and the current state of the game will be displayed in your browser.
-    
-    In order to use the `take_screenshot` or `visualize` functions in `textworld.render`,
-    you'll need to install either the [Chrome](https://sites.google.com/a/chromium.org/chromedriver/) 
-    or [Firefox](https://github.com/mozilla/geckodriver) webdriver (depending on whichever
-    browser you have installed).
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -78,3 +78,26 @@ For more information about TextWorld, check the [documentation](https://aka.ms/t
 
 ## Notebooks
 Check the notebooks provided with the framework to see how the framework can be used.
+
+## Citing TextWorld
+If you use TextWorld, please cite the following BibTex:
+```
+@Article{cote18textworld,
+  author = {Marc-Alexandre C\^ot\'e and
+            \'Akos K\'ad\'ar and
+            Xingdi Yuan and
+            Ben Kybartas and
+            Tavian Barnes and
+            Emery Fine and
+            James Moore and
+            Matthew Hausknecht and
+            Layla El Asri and
+            Mahmoud Adada and
+            Wendy Tay and
+            Adam Trischler},
+  title = {TextWorld: A Learning Environment for Text-based Games},
+  journal = {CoRR},
+  volume = {abs/1806.11532},
+  year = {2018}
+}
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,7 @@ RUN apt-get install -qy \
     python3-dev \
     python3-pip \
     uuid-dev \
-    wget \
-    xdot
+    wget
 
 # set display name for x-server for selenium tests
 ENV DISPLAY=:99

--- a/scripts/tw-make
+++ b/scripts/tw-make
@@ -11,9 +11,9 @@ import textworld
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(add_help=False)
+    general_parser = argparse.ArgumentParser(add_help=False)
 
-    general_group = parser.add_argument_group('General settings')
+    general_group = general_parser.add_argument_group('General settings')
     general_group.add_argument("--output", default="./gen_games/", metavar="PATH",
                                help="Output folder to save generated game files.")
     general_group.add_argument('--seed', type=int)
@@ -21,7 +21,7 @@ def parse_args():
                                help="Display the resulting game.")
     general_group.add_argument("-v", "--verbose", action="store_true")
 
-    cfg_group = parser.add_argument_group('Grammar settings')
+    cfg_group = general_parser.add_argument_group('Grammar settings')
     cfg_group.add_argument("--theme", default="house",
                            help="Theme to use for generating the text. Default: %(default)s")
     cfg_group.add_argument("--include-adj", action="store_true",
@@ -35,10 +35,10 @@ def parse_args():
     cfg_group.add_argument("--blend-instructions", action="store_true",
                            help="Blend instructions across consecutive actions.")
 
-    general_parser = parser
-
     parser = argparse.ArgumentParser(parents=[general_parser])
-    subparsers = parser.add_subparsers(dest="subcommand", help='Kind of game to make.')
+    subparsers = parser.add_subparsers(dest="subcommand",
+                                       required=True, 
+                                       help='Kind of game to make.')
 
     custom_parser = subparsers.add_parser("custom", parents=[general_parser],
                                           help='Make a custom game.')

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'nose==1.3.7',
     ],
     extras_require={
-        'vis': ['pybars3>=0.9.3', 'flask>=1.0.2', 'selenium>=3.12.0', 'gevent>=1.3.2', 'pillow>=5.1.0', 'chromedriver_installer'],
+        'vis': ['pybars3>=0.9.3', 'flask>=1.0.2', 'selenium>=3.12.0', 'gevent>=1.3.2', 'pillow>=5.1.0'],
         'prompt': ['prompt-toolkit<2.0.0,>=1.0.15'],
         'gym': ['gym_textworld'],
     },

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'nose==1.3.7',
     ],
     extras_require={
-        'vis': ['pybars3>=0.9.3', 'flask>=1.0.2', 'selenium>=3.12.0', 'gevent>=1.3.2', 'pillow>=5.1.0'],
+        'vis': ['pybars3>=0.9.3', 'flask>=1.0.2', 'selenium>=3.12.0', 'gevent>=1.3.2', 'pillow>=5.1.0', 'chromedriver_installer'],
         'prompt': ['prompt-toolkit<2.0.0,>=1.0.15'],
         'gym': ['gym_textworld'],
     },

--- a/textworld/__init__.py
+++ b/textworld/__init__.py
@@ -1,149 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
-
-import os
 import warnings
-from os.path import join as pjoin
-from typing import Optional, Mapping, Tuple
 
 from textworld.utils import g_rng
-from textworld.utils import maybe_mkdir
 
 from textworld.core import Environment, GameState, Agent
 from textworld.generator import Game, GameMaker
 
-import textworld.challenges
-import textworld.generator
-import textworld.agents
-
-from textworld.envs import FrotzEnvironment
-from textworld.envs import GlulxEnvironment
-from textworld.envs import JerichoEnvironment
-from textworld.envs import CUSTOM_ENVIRONMENTS
-
 from textworld.generator import TextworldGenerationWarning
+
+from textworld.helpers import make, play, start
 
 # By default disable warning related to game generation.
 warnings.simplefilter("ignore", TextworldGenerationWarning)
-
-# TODO: move that constant in a config file.
-DEFAULT_GAMES_REPOSITORY = pjoin(".", "games")
-
-
-def start(filename: str) -> Environment:
-    """ Starts a TextWorld environment to play a game.
-
-    Args:
-        filename: Path to the game file.
-
-    Returns:
-        TextWorld environment running the provided game.
-
-    """
-    # Check the game file exists.
-    if not os.path.isfile(filename):
-        # Maybe it refers to a file in "games" directory.
-        tentative = pjoin(DEFAULT_GAMES_REPOSITORY, filename)
-
-        if not os.path.isfile(tentative):
-            msg = "Unable to find game: '{}' or '{}'"
-            msg = msg.format(os.path.abspath(filename), os.path.abspath(tentative))
-            raise IOError(msg)
-
-        filename = tentative
-
-    # Guess the backend from the extension.
-    backend = "glulx" if filename.endswith(".ulx") else "zmachine"
-
-    if backend == "zmachine":
-        if os.path.basename(filename) in CUSTOM_ENVIRONMENTS:
-            env = CUSTOM_ENVIRONMENTS[os.path.basename(filename)](filename)
-        elif JerichoEnvironment:
-            env = JerichoEnvironment(filename)
-        else:
-            env = FrotzEnvironment(filename)
-
-    elif backend == "glulx":
-        env = GlulxEnvironment(filename)
-    else:
-        msg = "Unsupported backend: {}".format(backend)
-        raise ValueError(msg)
-
-    return env
-
-
-def play(game_file: str, agent: Optional[Agent] = None, max_nb_steps: int = 1000,
-         wrapper: Optional[callable] = None, silent: bool = False) -> None:
-    """ Convenience function to play a text-based game.
-
-    Args:
-        game_file: Path to the game file.
-        agent: Agent that will play the game. Default: HumanAgent(autocompletion=True).
-        max_nb_steps: Maximum number of steps allowed. Default: 1000.
-        wrapper: Wrapper to apply to the environment.
-        silent: Do not render anything to screen.
-
-    Notes:
-        Use script :command:`tw-play` for more options.
-    """
-    env = start(game_file)
-    if agent is None:
-        try:
-            agent = textworld.agents.HumanAgent(autocompletion=True)
-        except AttributeError:
-            agent = textworld.agents.HumanAgent()
-
-    agent.reset(env)
-    if wrapper is not None:
-        env = wrapper(env)
-
-    game_state = env.reset()
-    if not silent:
-        env.render(mode="human")
-
-    reward = 0
-    done = False
-    try:
-        for _ in range(max_nb_steps):
-            command = agent.act(game_state, reward, done)
-            game_state, reward, done = env.step(command)
-
-            if not silent:
-                env.render(mode="human")
-
-            if done:
-                break
-
-    except KeyboardInterrupt:
-        pass  # Stop the game.
-    finally:
-        env.close()
-
-    if not silent:
-        msg = "Done after {} steps. Score {}/{}."
-        msg = msg.format(game_state.nb_moves, game_state.score, game_state.max_score)
-        print(msg)
-
-
-def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2,
-         grammar_flags: Mapping = {}, seed: int = None,
-         games_dir: str = "./gen_games/") -> Tuple[str, Game]:
-    """ Makes a text-based game.
-
-    Args:
-        world_size: Number of rooms in the world.
-        nb_objects: Number of objects in the world.
-        quest_length: Minimum number of actions the quest requires to be completed.
-        grammar_flags: Grammar options.
-        seed: Random seed for the game generation process.
-        games_dir: Path to the directory where the game will be saved.
-
-    Returns:
-        A tuple containing the path to the game file, and its corresponding Game's object.
-    """
-    g_rng.set_seed(seed)
-    game_name = "game_{}".format(seed)
-    game = textworld.generator.make_game(world_size, nb_objects, quest_length, grammar_flags)
-    game_file = textworld.generator.compile_game(game, game_name, games_folder=games_dir, force_recompile=True)
-    return game_file, game

--- a/textworld/envs/__init__.py
+++ b/textworld/envs/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
-
+import textworld.envs.wrappers
 from textworld.envs.zmachine.frotz import FrotzEnvironment
 from textworld.envs.glulx.git_glulx_ml import GitGlulxMLEnvironment as GlulxEnvironment
 

--- a/textworld/envs/__init__.py
+++ b/textworld/envs/__init__.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
-import textworld.envs.wrappers
 from textworld.envs.zmachine.frotz import FrotzEnvironment
 from textworld.envs.glulx.git_glulx_ml import GitGlulxMLEnvironment as GlulxEnvironment
 

--- a/textworld/generator/maker.py
+++ b/textworld/generator/maker.py
@@ -23,6 +23,7 @@ from textworld.generator.chaining import get_failing_constraints
 from textworld.generator.game import Game, World, Quest
 from textworld.generator.graph_networks import DIRECTIONS
 from textworld.render import visualize
+from textworld.envs.wrappers import Recorder
 
 
 class MissingPlayerError(ValueError):
@@ -511,7 +512,7 @@ class GameMaker:
         """
         with make_temp_directory() as tmpdir:
             game_file = self.compile(pjoin(tmpdir, "record_quest"))
-            recorder = textworld.envs.wrappers.Recorder()
+            recorder = Recorder()
             textworld.play(game_file, wrapper=recorder)
 
         # Skip "None" actions.
@@ -549,7 +550,7 @@ class GameMaker:
         with make_temp_directory() as tmpdir:
             try:
                 game_file = self.compile(pjoin(tmpdir, "record_quest"))
-                recorder = textworld.envs.wrappers.Recorder()
+                recorder = Recorder()
                 agent = textworld.agents.WalkthroughAgent(commands)
                 textworld.play(game_file, agent=agent, wrapper=recorder, silent=True)
             except textworld.agents.WalkthroughDone:

--- a/textworld/helpers.py
+++ b/textworld/helpers.py
@@ -1,0 +1,142 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+
+import os
+from os.path import join as pjoin
+from typing import Optional, Mapping, Tuple
+
+from textworld.utils import g_rng
+
+from textworld.core import Environment, GameState, Agent
+from textworld.generator import Game, GameMaker
+
+from textworld.envs import FrotzEnvironment
+from textworld.envs import GlulxEnvironment
+from textworld.envs import JerichoEnvironment
+from textworld.envs import CUSTOM_ENVIRONMENTS
+
+from textworld.agents import HumanAgent
+
+from textworld.generator import make_game, compile_game
+
+# TODO: move that constant in a config file.
+DEFAULT_GAMES_REPOSITORY = pjoin(".", "games")
+
+
+def start(filename: str) -> Environment:
+    """ Starts a TextWorld environment to play a game.
+
+    Args:
+        filename: Path to the game file.
+
+    Returns:
+        TextWorld environment running the provided game.
+
+    """
+    # Check the game file exists.
+    if not os.path.isfile(filename):
+        # Maybe it refers to a file in "games" directory.
+        tentative = pjoin(DEFAULT_GAMES_REPOSITORY, filename)
+
+        if not os.path.isfile(tentative):
+            msg = "Unable to find game: '{}' or '{}'"
+            msg = msg.format(os.path.abspath(filename), os.path.abspath(tentative))
+            raise IOError(msg)
+
+        filename = tentative
+
+    # Guess the backend from the extension.
+    backend = "glulx" if filename.endswith(".ulx") else "zmachine"
+
+    if backend == "zmachine":
+        if os.path.basename(filename) in CUSTOM_ENVIRONMENTS:
+            env = CUSTOM_ENVIRONMENTS[os.path.basename(filename)](filename)
+        elif JerichoEnvironment:
+            env = JerichoEnvironment(filename)
+        else:
+            env = FrotzEnvironment(filename)
+
+    elif backend == "glulx":
+        env = GlulxEnvironment(filename)
+    else:
+        msg = "Unsupported backend: {}".format(backend)
+        raise ValueError(msg)
+
+    return env
+
+
+def play(game_file: str, agent: Optional[Agent] = None, max_nb_steps: int = 1000,
+         wrapper: Optional[callable] = None, silent: bool = False) -> None:
+    """ Convenience function to play a text-based game.
+
+    Args:
+        game_file: Path to the game file.
+        agent: Agent that will play the game. Default: HumanAgent(autocompletion=True).
+        max_nb_steps: Maximum number of steps allowed. Default: 1000.
+        wrapper: Wrapper to apply to the environment.
+        silent: Do not render anything to screen.
+
+    Notes:
+        Use script :command:`tw-play` for more options.
+    """
+    env = start(game_file)
+    if agent is None:
+        try:
+            agent = HumanAgent(autocompletion=True)
+        except AttributeError:
+            agent = HumanAgent()
+
+    agent.reset(env)
+    if wrapper is not None:
+        env = wrapper(env)
+
+    game_state = env.reset()
+    if not silent:
+        env.render(mode="human")
+
+    reward = 0
+    done = False
+    try:
+        for _ in range(max_nb_steps):
+            command = agent.act(game_state, reward, done)
+            game_state, reward, done = env.step(command)
+
+            if not silent:
+                env.render(mode="human")
+
+            if done:
+                break
+
+    except KeyboardInterrupt:
+        pass  # Stop the game.
+    finally:
+        env.close()
+
+    if not silent:
+        msg = "Done after {} steps. Score {}/{}."
+        msg = msg.format(game_state.nb_moves, game_state.score, game_state.max_score)
+        print(msg)
+
+
+def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2,
+         grammar_flags: Mapping = {}, seed: int = None,
+         games_dir: str = "./gen_games/") -> Tuple[str, Game]:
+    """ Makes a text-based game.
+
+    Args:
+        world_size: Number of rooms in the world.
+        nb_objects: Number of objects in the world.
+        quest_length: Minimum number of actions the quest requires to be completed.
+        grammar_flags: Grammar options.
+        seed: Random seed for the game generation process.
+        games_dir: Path to the directory where the game will be saved.
+
+    Returns:
+        A tuple containing the path to the game file, and its corresponding Game's object.
+    """
+    g_rng.set_seed(seed)
+    game_name = "game_{}".format(seed)
+    game = make_game(world_size, nb_objects, quest_length, grammar_flags)
+    game_file = compile_game(game, game_name, games_folder=games_dir, force_recompile=True)
+    return game_file, game

--- a/textworld/render/__init__.py
+++ b/textworld/render/__init__.py
@@ -3,3 +3,4 @@
 
 
 from textworld.render.render import load_state, load_state_from_game_state, visualize
+import textworld.render.serve

--- a/textworld/render/__init__.py
+++ b/textworld/render/__init__.py
@@ -3,4 +3,4 @@
 
 
 from textworld.render.render import load_state, load_state_from_game_state, visualize
-import textworld.render.serve
+from textworld.render.serve import get_html_template

--- a/textworld/render/render.py
+++ b/textworld/render/render.py
@@ -369,7 +369,8 @@ def visualize(world: Union[Game, State, GlulxGameState, World],
 
     state["command"] = ""
     state["history"] = ""
-    html = textworld.render.serve.get_html_template(game_state=json.dumps(state))
+    from textworld.render.serve import get_html_template
+    html = get_html_template(game_state=json.dumps(state))
     tmpdir = maybe_mkdir(pjoin(tempfile.gettempdir(), "textworld"))
     fh, filename = tempfile.mkstemp(suffix=".html", dir=tmpdir, text=True)
     url = 'file://' + filename


### PR DESCRIPTION
This PR regroups a few minor fixes.

- remove xdot as a system dependency;
- automatically install chromedriver when `pip install textworld[vis]` is used;
- add clearer error messages in tw-make;
- add missing import to use `textworld.render.visualize` (fixes #8).