### PR TITLE
setup.py: Pin versions to fix Python 3.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,19 @@ setup(
         'nose==1.3.7',
     ],
     extras_require={
-        'vis': ['pybars3>=0.9.3', 'flask>=1.0.2', 'selenium>=3.12.0', 'gevent>=1.3.2', 'pillow>=5.1.0'],
-        'prompt': ['prompt-toolkit<2.0.0,>=1.0.15'],
-        'gym': ['gym_textworld'],
+        'vis': [
+            'pybars3>=0.9.3',
+            'flask>=1.0.2',
+            'selenium>=3.12.0',
+            'greenlet==0.4.13',
+            'gevent==1.3.5',
+            'pillow>=5.1.0',
+        ],
+        'prompt': [
+            'prompt-toolkit<2.0.0,>=1.0.15',
+        ],
+        'gym': [
+            'gym_textworld',
+        ],
     },
 )


### PR DESCRIPTION
This is a temporary workaround for https://github.com/gevent/gevent/issues/1260