### PR TITLE
Disable automatic door creation

### DIFF
--- a/textworld/generator/__init__.py
+++ b/textworld/generator/__init__.py
@@ -180,7 +180,7 @@ def make_game(world_size: int, nb_objects: int, quest_length: int,
     options.max_depth = quest_length
     options.create_variables = True
     options.rng = rngs['rng_quest']
-    options.restricted_types = {"r"}
+    options.restricted_types = {"r", "d"}
     chain = sample_quest(world.state, options)
     quest = Quest(chain.actions)
 


### PR DESCRIPTION
In the current master the following fails:
`tw-make custom  --quest-length 3 --seed 24853`

```
CouldNotCompileGameError: 
-== ni =-
FAIL: 1
Inform 7 build 6M62 has started.
++ 0% (Reading text)
I've now read your source text, which is 3563 words long.
++ 5% (Analysing sentences)
I've also read Standard Rules by Graham Nelson, which is 42655 words long.
I've also read English Language by Graham Nelson, which is 2297 words long.
I've also read Basic Screen Effects by Emily Short, which is 2218 words long.
++ 15% (Drawing inferences)
  >--> r_4, a room, seems to have a map connection which goes through d_1, a
    door: but that doesn't seem physically possible, since d_1 seems to connect
    to r_1 in the same direction. Something's twisty here.
++ Ended: Translation failed: 1 problem found
Inform 7 has finished.
========
*** Usually this means a compilation error.
*** See ./gen_games/game_24853.ni for more information.
```