### PR TITLE
Better-looking feedback message for the take command.

### DIFF
--- a/textworld/core.py
+++ b/textworld/core.py
@@ -163,7 +163,7 @@ class Environment:
     >>> command = "take keycard"  # Command to send to the game.
     >>> game_state, reward, done = env.step(command)
     >>> env.render()
-    Taken
+    You pick up the keycard from the ground.
     """
 
     @property

--- a/textworld/envs/glulx/tests/test_git_glulx_ml.py
+++ b/textworld/envs/glulx/tests/test_git_glulx_ml.py
@@ -100,9 +100,9 @@ class TestGlulxGameState(unittest.TestCase):
 
         # Check feedback for dropping and taking the carrot.
         game_state, _, _ = self.env.step("drop carrot")
-        assert game_state.feedback.strip() == "Dropped.", game_state.feedback
+        assert "drop the carrot on the ground" in game_state.feedback
         game_state, _, _ = self.env.step("take carrot")
-        assert game_state.feedback.strip() == "Taken.", game_state.feedback
+        assert "pick up the carrot from the ground" in game_state.feedback
 
     def test_command_feedback(self):
         assert self.game_state.command_feedback.strip() == ""
@@ -113,9 +113,9 @@ class TestGlulxGameState(unittest.TestCase):
 
         # Check command feedback for dropping and taking the carrot.
         game_state, _, _ = self.env.step("drop carrot")
-        assert game_state.command_feedback.strip() == "Dropped.", game_state.command_feedback
+        assert "drop the carrot on the ground" in game_state.command_feedback
         game_state, _, _ = self.env.step("take carrot")
-        assert game_state.command_feedback.strip() == "Taken.", game_state.command_feedback
+        assert "pick up the carrot from the ground" in game_state.command_feedback
 
     def test_inventory(self):
         assert "carrot" in self.game_state.inventory

--- a/textworld/generator/inform7/tests/test_world2inform7.py
+++ b/textworld/generator/inform7/tests/test_world2inform7.py
@@ -199,7 +199,7 @@ def test_take_all_and_variants():
         env.reset()
 
         game_state, _, done = env.step("take all ball")
-        assert "red ball: Taken." in game_state.feedback
-        assert "blue ball: Taken." in game_state.feedback
+        assert "red ball:" in game_state.feedback
+        assert "blue ball:" in game_state.feedback
         assert "red ball" in game_state.inventory
         assert "blue ball" in game_state.inventory

--- a/textworld/generator/inform7/world2inform7.py
+++ b/textworld/generator/inform7/world2inform7.py
@@ -462,6 +462,25 @@ def generate_inform7_source(game, seed=1234, use_i7_description=False):
 
     """)
 
+    # Customize reporting of the "take" action.
+    # Ref: http://inform7.com/learn/man/RB_6_8.html
+    source += textwrap.dedent("""\
+    The taking action has an object called previous locale (matched as "from").
+
+    Setting action variables for taking: 
+        now previous locale is the holder of the noun.
+
+    Report taking something from the location: 
+        say "You pick up [the noun] from the ground." instead.
+
+    Report taking something: 
+        say "You take [the noun] from [the previous locale]." instead.
+
+    Report dropping something: 
+        say "You drop [the noun] on the ground." instead.
+
+    """)
+
     # Special command to print game state.
     source += textwrap.dedent("""\
     The print state option is a truth state that varies.


### PR DESCRIPTION
This PR offers a better-looking feedback message for reporting the "take" and "drop" actions. For instance, instead of simply saying "Taken" or "Dropped" it nows prints something like 

```
> take keycard

You pick up the keycard from the ground.

> drop keycard
You drop the keycard on the ground.
```