### PR TITLE
Moved visualization imports inside functions that need them.

### DIFF
--- a/textworld/render/__init__.py
+++ b/textworld/render/__init__.py
@@ -3,4 +3,3 @@
 
 
 from textworld.render.render import load_state, load_state_from_game_state, visualize
-from textworld.render.serve import get_html_template

--- a/textworld/render/render.py
+++ b/textworld/render/render.py
@@ -347,6 +347,7 @@ def visualize(world: Union[Game, State, GlulxGameState, World],
     """
     try:
         import webbrowser
+        from textworld.render.serve import get_html_template
     except ImportError:
         raise ImportError('Visualization dependencies not installed. Try running `pip install textworld[vis]`')
 
@@ -369,7 +370,6 @@ def visualize(world: Union[Game, State, GlulxGameState, World],
 
     state["command"] = ""
     state["history"] = ""
-    from textworld.render.serve import get_html_template
     html = get_html_template(game_state=json.dumps(state))
     tmpdir = maybe_mkdir(pjoin(tempfile.gettempdir(), "textworld"))
     fh, filename = tempfile.mkstemp(suffix=".html", dir=tmpdir, text=True)


### PR DESCRIPTION
Avoid importing visualization function at the top-level. This PR fixes #27. In the future, we might install all dependencies by default.