### PR TITLE
BF: Object names disambiguation

### DIFF
--- a/textworld/generator/inform7/world2inform7.py
+++ b/textworld/generator/inform7/world2inform7.py
@@ -326,14 +326,15 @@ def generate_inform7_source(game, seed=1234, use_i7_description=False):
 
     """)
 
-    # Refeering to an object by it whole name shouldn't be ambiguous.
+    # Refeering to an object by its whole name shouldn't be ambiguous.
     source += textwrap.dedent("""\
-    Does the player mean doing something with something (called target):
-	if the player's command matches the text printed name of the target and the second noun is nothing:
-		it is very likely;
-	if the player's command matches the text printed name of the target and the player's command matches the text printed name of the second noun:
-		it is very likely.  [Handle action with two arguments.]
-
+    Does the player mean doing something:
+        if the noun is not nothing and the second noun is nothing and the player's command matches the text printed name of the noun:
+            it is likely;
+        if the noun is nothing and the second noun is not nothing and the player's command matches the text printed name of the second noun:
+            it is likely;
+        if the noun is not nothing and the second noun is not nothing and the player's command matches the text printed name of the noun and the player's command matches the text printed name of the second noun:
+            it is very likely.  [Handle action with two arguments.]
     """)
 
     # Useful for listing room contents with their properties.
@@ -393,7 +394,8 @@ def generate_inform7_source(game, seed=1234, use_i7_description=False):
         remove the list of containers from L;
         remove the list of supporters from L;
         remove the list of doors from L;
-        say "There is [L with indefinite articles] on the floor.";
+        if the number of entries in L is greater than 0:
+            say "There is [L with indefinite articles] on the floor.";
         
     """)
 


### PR DESCRIPTION
Still related to #24. It seems the order in which the objects are added in Inform7 matters. This PR makes the objects names disambiguation code more robust to that. 