### PR TITLE
Support subquests

### DIFF
--- a/scripts/tw-make
+++ b/scripts/tw-make
@@ -46,6 +46,8 @@ def parse_args():
                                help="Nb. of objects in the world.")
     custom_parser.add_argument("--quest-length", type=int, default=5, metavar="LENGTH",
                                help="Minimum nb. of actions the quest requires to be completed.")
+    custom_parser.add_argument("--quest-breadth", type=int, default=3, metavar="BREADTH",
+                               help="Control how non-linear a quest can be.")
 
     challenge_parser = subparsers.add_parser("challenge", parents=[general_parser],
                                              help='Generate a game for one of the challenges.')
@@ -72,7 +74,7 @@ if __name__ == "__main__":
     }
 
     if args.subcommand == "custom":
-        game_file, game = textworld.make(args.world_size, args.nb_objects, args.quest_length, grammar_flags,
+        game_file, game = textworld.make(args.world_size, args.nb_objects, args.quest_length, args.quest_breadth, grammar_flags,
                                          seed=args.seed, games_dir=args.output)
 
     elif args.subcommand == "challenge":
@@ -87,7 +89,7 @@ if __name__ == "__main__":
 
     print("Game generated: {}".format(game_file))
     if args.verbose:
-        print(game.quests[0].desc)
+        print(game.objective)
 
     if args.view:
         textworld.render.visualize(game, interactive=True)

--- a/scripts/tw-stats
+++ b/scripts/tw-stats
@@ -38,7 +38,7 @@ if __name__ == "__main__":
             continue
 
         if len(game.quests) > 0:
-            objectives[game_filename] = game.quests[0].desc
+            objectives[game_filename] = game.objective
 
         names |= set(info.name for info in game.infos.values() if info.name is not None)
         game_logger.collect(game)

--- a/tests/test_make_game.py
+++ b/tests/test_make_game.py
@@ -18,6 +18,7 @@ def test_making_game_with_names_to_exclude():
         game_file2, game2 = textworld.make(2, 20, 3, 3, {"names_to_exclude": game1_objects_names},
                                            seed=123, games_dir=tmpdir)
         game2_objects_names = [info.name for info in game2.infos.values() if info.name is not None]
+        game2.grammar.flags.encode()
         assert len(set(game1_objects_names) & set(game2_objects_names)) == 0
 
 

--- a/tests/test_make_game.py
+++ b/tests/test_make_game.py
@@ -11,11 +11,11 @@ def test_making_game_with_names_to_exclude():
     g_rng.set_seed(42)
 
     with make_temp_directory(prefix="test_render_wrapper") as tmpdir:
-        game_file1, game1 = textworld.make(2, 20, 3, {"names_to_exclude": []},
+        game_file1, game1 = textworld.make(2, 20, 3, 3, {"names_to_exclude": []},
                                            seed=123, games_dir=tmpdir)
 
         game1_objects_names = [info.name for info in game1.infos.values() if info.name is not None]
-        game_file2, game2 = textworld.make(2, 20, 3, {"names_to_exclude": game1_objects_names},
+        game_file2, game2 = textworld.make(2, 20, 3, 3, {"names_to_exclude": game1_objects_names},
                                            seed=123, games_dir=tmpdir)
         game2_objects_names = [info.name for info in game2.infos.values() if info.name is not None]
         assert len(set(game1_objects_names) & set(game2_objects_names)) == 0
@@ -24,8 +24,8 @@ def test_making_game_with_names_to_exclude():
 def test_making_game_is_reproducible_with_seed():
     grammar_flags = {}
     with make_temp_directory(prefix="test_render_wrapper") as tmpdir:
-        game_file1, game1 = textworld.make(2, 20, 3, grammar_flags, seed=123, games_dir=tmpdir)
-        game_file2, game2 = textworld.make(2, 20, 3, grammar_flags, seed=123, games_dir=tmpdir)
+        game_file1, game1 = textworld.make(2, 20, 3, 3, grammar_flags, seed=123, games_dir=tmpdir)
+        game_file2, game2 = textworld.make(2, 20, 3, 3, grammar_flags, seed=123, games_dir=tmpdir)
         assert game_file1 == game_file2
         assert game1 == game2
         # Make sure they are not the same Python objects.

--- a/tests/test_play_generated_games.py
+++ b/tests/test_play_generated_games.py
@@ -16,7 +16,7 @@ def test_play_generated_games():
         # Sample game specs.
         world_size = rng.randint(1, 10)
         nb_objects = rng.randint(0, 20)
-        quest_length = rng.randint(1, 5)
+        quest_length = rng.randint(2, 5)
         quest_breadth = rng.randint(3, 7)
         game_seed = rng.randint(0, 65365)
         grammar_flags = {}  # Default grammar.

--- a/tests/test_play_generated_games.py
+++ b/tests/test_play_generated_games.py
@@ -16,12 +16,13 @@ def test_play_generated_games():
         # Sample game specs.
         world_size = rng.randint(1, 10)
         nb_objects = rng.randint(0, 20)
-        quest_length = rng.randint(1, 10)
+        quest_length = rng.randint(1, 5)
+        quest_breadth = rng.randint(3, 7)
         game_seed = rng.randint(0, 65365)
         grammar_flags = {}  # Default grammar.
 
         with make_temp_directory(prefix="test_play_generated_games") as tmpdir:
-            game_file, game = textworld.make(world_size, nb_objects, quest_length, grammar_flags,
+            game_file, game = textworld.make(world_size, nb_objects, quest_length, quest_breadth, grammar_flags,
                                              seed=game_seed, games_dir=tmpdir)
 
             # Solve the game using WalkthroughAgent.
@@ -47,7 +48,7 @@ def test_play_generated_games():
                 game_state, reward, done = env.step(command)
 
                 if done:
-                    msg = "Finished before playing `max_steps` steps."
+                    msg = "Finished before playing `max_steps` steps because of command '{}'.".format(command)
                     if game_state.has_won:
                         msg += " (winning)"
                         assert game_state._game_progression.winning_policy == []

--- a/tests/test_play_generated_games.py
+++ b/tests/test_play_generated_games.py
@@ -51,7 +51,7 @@ def test_play_generated_games():
                     msg = "Finished before playing `max_steps` steps because of command '{}'.".format(command)
                     if game_state.has_won:
                         msg += " (winning)"
-                        assert game_state._game_progression.winning_policy == []
+                        assert len(game_state._game_progression.winning_policy) == 0
 
                     if game_state.has_lost:
                         msg += " (losing)"

--- a/tests/test_textworld.py
+++ b/tests/test_textworld.py
@@ -58,7 +58,7 @@ class TestIntegration(unittest.TestCase):
         agent = textworld.agents.WalkthroughAgent()
         env = textworld.start(self.game_file)
         env.activate_state_tracking()
-        commands = self.game.quests[0].commands
+        commands = self.game.quests[-1].commands
         agent.reset(env)
         game_state = env.reset()
 

--- a/tests/test_tw-play.py
+++ b/tests/test_tw-play.py
@@ -7,9 +7,9 @@ import textworld
 from textworld.utils import make_temp_directory
 
 
-def test_making_a_custom_game():                                             
+def test_playing_a_game():                                             
     with make_temp_directory(prefix="test_tw-play") as tmpdir:    
-        game_file, _ = textworld.make(5, 10, 5, {}, seed=1234, games_dir=tmpdir)
+        game_file, _ = textworld.make(5, 10, 5, 4, {}, seed=1234, games_dir=tmpdir)
 
         command = ["tw-play", "--max-steps", "100", "--mode", "random", game_file]
         assert check_call(command) == 0

--- a/textworld/agents/walkthrough.py
+++ b/textworld/agents/walkthrough.py
@@ -26,13 +26,7 @@ class WalkthroughAgent(Agent):
             raise NameError(msg)
 
         # Load command from the generated game.
-        from textworld.generator.game import GameProgression, Quest
-        from textworld.generator.inform7 import gen_commands_from_actions
-
-        game_progression = GameProgression(env.game)
-        main_quest = Quest(actions=game_progression.winning_policy)
-        commands = gen_commands_from_actions(main_quest.actions, env.game.infos)
-        self._commands = iter(commands)
+        self._commands = iter(env.game.main_quest.commands)
 
     def act(self, game_state, reward, done):
         try:

--- a/textworld/agents/walkthrough.py
+++ b/textworld/agents/walkthrough.py
@@ -26,7 +26,7 @@ class WalkthroughAgent(Agent):
             raise NameError(msg)
 
         # Load command from the generated game.
-        self._commands = iter(env.game.quests[0].commands)
+        self._commands = iter(env.game.quests[-1].commands)
 
     def act(self, game_state, reward, done):
         try:

--- a/textworld/agents/walkthrough.py
+++ b/textworld/agents/walkthrough.py
@@ -26,7 +26,13 @@ class WalkthroughAgent(Agent):
             raise NameError(msg)
 
         # Load command from the generated game.
-        self._commands = iter(env.game.quests[-1].commands)
+        from textworld.generator.game import GameProgression, Quest
+        from textworld.generator.inform7 import gen_commands_from_actions
+
+        game_progression = GameProgression(env.game)
+        main_quest = Quest(actions=game_progression.winning_policy)
+        commands = gen_commands_from_actions(main_quest.actions, env.game.infos)
+        self._commands = iter(commands)
 
     def act(self, game_state, reward, done):
         try:

--- a/textworld/envs/glulx/git_glulx_ml.py
+++ b/textworld/envs/glulx/git_glulx_ml.py
@@ -146,7 +146,7 @@ class GlulxGameState(textworld.GameState):
         """
         output = _strip_input_prompt_symbol(output)
         super().init(output)
-        self._game_progression = GameProgression(game, track_quest=compute_intermediate_reward)
+        self._game_progression = GameProgression(game, track_quests=compute_intermediate_reward)
         self._state_tracking = state_tracking
         self._compute_intermediate_reward = compute_intermediate_reward and len(game.quests) > 0
         self._objective = game.objective

--- a/textworld/envs/glulx/git_glulx_ml.py
+++ b/textworld/envs/glulx/git_glulx_ml.py
@@ -149,10 +149,7 @@ class GlulxGameState(textworld.GameState):
         self._game_progression = GameProgression(game, track_quest=compute_intermediate_reward)
         self._state_tracking = state_tracking
         self._compute_intermediate_reward = compute_intermediate_reward and len(game.quests) > 0
-
-        self._objective = ""
-        if len(game.quests) > 0:
-            self._objective = game.quests[0].desc
+        self._objective = game.objective
 
     def view(self) -> "GlulxGameState":
         """
@@ -317,6 +314,7 @@ class GlulxGameState(textworld.GameState):
 
     @property
     def score(self):
+        # XXX: Should the score reflect the sum of all subquests' reward?
         if self.has_won:
             return 1
         elif self.has_lost:
@@ -326,6 +324,7 @@ class GlulxGameState(textworld.GameState):
 
     @property
     def max_score(self):
+        # XXX: Should the score reflect the sum of all subquests' reward?
         return 1
 
     @property

--- a/textworld/envs/wrappers/tests/test_viewer.py
+++ b/textworld/envs/wrappers/tests/test_viewer.py
@@ -17,7 +17,7 @@ def test_html_viewer():
     num_items = 10
     g_rng.set_seed(1234)
     grammar_flags = {"theme": "house", "include_adj": True}
-    game = textworld.generator.make_game(world_size=num_nodes, nb_objects=num_items, quest_length=3, grammar_flags=grammar_flags)
+    game = textworld.generator.make_game(world_size=num_nodes, nb_objects=num_items, quest_length=3, quest_breadth=1, grammar_flags=grammar_flags)
 
     game_name = "test_html_viewer_wrapper"
     with make_temp_directory(prefix=game_name) as tmpdir:

--- a/textworld/generator/__init__.py
+++ b/textworld/generator/__init__.py
@@ -147,7 +147,7 @@ def make_game_with(world, quests=None, grammar=None):
     return game
 
 
-def make_game(world_size: int, nb_objects: int, quest_length: int,
+def make_game(world_size: int, nb_objects: int, quest_length: int, quest_breadth: int,
               grammar_flags: Mapping = {},
               rngs: Optional[Dict[str, RandomState]] = None
               ) -> Game:
@@ -158,6 +158,7 @@ def make_game(world_size: int, nb_objects: int, quest_length: int,
         world_size: Number of rooms in the world.
         nb_objects: Number of objects in the world.
         quest_length: Minimum nb. of actions the quest requires to be completed.
+        quest_breadth: How many branches the quest can have.
         grammar_flags: Options for the grammar.
 
     Returns:
@@ -175,14 +176,34 @@ def make_game(world_size: int, nb_objects: int, quest_length: int,
     world = make_world(world_size, nb_objects=0, rngs=rngs)
 
     # Sample a quest according to quest_length.
-    options = ChainingOptions()
+    class Options(ChainingOptions):
+
+        def get_rules(self, depth):
+            if depth == 0:
+		# Last action should not be "go <dir>".
+                return data.get_rules().get_matching("^(?!go.*).*")
+            else:
+                return super().get_rules(depth)
+
+    options = Options()
     options.backward = True
+    options.min_depth = quest_length
     options.max_depth = quest_length
+    options.min_breadth = quest_breadth
+    options.max_breadth = quest_breadth
     options.create_variables = True
     options.rng = rngs['rng_quest']
     options.restricted_types = {"r", "d"}
     chain = sample_quest(world.state, options)
+
+    subquests = []
+    for i in range(1, len(chain.nodes)):
+        if chain.nodes[i].breadth != chain.nodes[i - 1].breadth:
+            quest = Quest(chain.actions[:i])
+            subquests.append(quest)
+
     quest = Quest(chain.actions)
+    subquests.append(quest)
 
     # Set the initial state required for the quest.
     world.state = chain.initial_state
@@ -191,7 +212,9 @@ def make_game(world_size: int, nb_objects: int, quest_length: int,
     world.populate(nb_objects, rng=rngs['rng_objects'])
 
     grammar = make_grammar(grammar_flags, rng=rngs['rng_grammar'])
-    game = make_game_with(world, [quest], grammar)
+    game = make_game_with(world, subquests, grammar)
+    game.change_grammar(grammar)
+
     return game
 
 

--- a/textworld/generator/__init__.py
+++ b/textworld/generator/__init__.py
@@ -180,16 +180,16 @@ def make_game(world_size: int, nb_objects: int, quest_length: int, quest_breadth
 
         def get_rules(self, depth):
             if depth == 0:
-		# Last action should not be "go <dir>".
+		        # Last action should not be "go <dir>".
                 return data.get_rules().get_matching("^(?!go.*).*")
             else:
                 return super().get_rules(depth)
 
     options = Options()
     options.backward = True
-    options.min_depth = quest_length
+    options.min_depth = 1
     options.max_depth = quest_length
-    options.min_breadth = quest_breadth
+    options.min_breadth = 1
     options.max_breadth = quest_breadth
     options.create_variables = True
     options.rng = rngs['rng_quest']

--- a/textworld/generator/data/logic/door.twl
+++ b/textworld/generator/data/logic/door.twl
@@ -34,7 +34,13 @@ type d : t {
         link3 :: link(r, d, r') & link(r, d', r') -> fail();
 
         # There cannot be more than four doors in a room.
-        dr2 :: link(r, d1: d, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        too_many_doors :: link(r, d1: d, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        
+        # There cannot be more than four doors in a room.
+        dr1 :: free(r, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr2 :: free(r, r1: r) & free(r, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr3 :: free(r, r1: r) & free(r, r2: r) & free(r, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr4 :: free(r, r1: r) & free(r, r2: r) & free(r, r3: r) & free(r, r4: r) & link(r, d5: d, r5: r) -> fail();
 
         free1 :: link(r, d, r') & free(r, r') & closed(d) -> fail();
         free2 :: link(r, d, r') & free(r, r') & locked(d) -> fail();

--- a/textworld/generator/data/text_grammars/house_instruction.twg
+++ b/textworld/generator/data/text_grammars/house_instruction.twg
@@ -112,7 +112,7 @@ action_seperator_go/north: #afterhave# gone north, ;#emptyinstruction1#;#emptyin
 action_seperator_go/east: #afterhave# gone east, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
 action_seperator_go/west: #afterhave# gone west, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
 action_separator_close: #afterhave# #closed# the #close_open_types#, ; #after# #closing# the #close_open_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
-action_separator_drop: #afterhave# #dropped# #obj_types#, ; #after# #dropping# #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_drop: #afterhave# #dropped# the #obj_types#, ; #after# #dropping# the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
 #Separator Symbols
 afterhave:After you have;Having;Once you have;If you have
 havetaken:taken;got;picked up

--- a/textworld/generator/dependency_tree.py
+++ b/textworld/generator/dependency_tree.py
@@ -3,6 +3,7 @@
 
 
 import textwrap
+from typing import List, Any
 
 from textworld.utils import uniquify
 
@@ -45,13 +46,17 @@ class DependencyTree:
 
         def push(self, node):
             if node == self:
-                return
-
+                return True
+            
+            added = False
             for child in self.children:
-                child.push(node)
+                added |= child.push(node)
 
             if self.element.depends_on(node.element) and not self.already_added(node):
                 self.children.append(node)
+                return True
+
+            return added
 
         def already_added(self, node):
             # We want to avoid duplicate information about dependencies.
@@ -62,11 +67,6 @@ class DependencyTree:
             # information that `node` would bring.
             if not node.element.is_distinct_from((child.element for child in self.children)):
                 return True
-
-            # for child in self.children:
-            #     # if node.element.value == child.element.value:
-            #     if not node.element.is_distinct_from((child.element):
-            #         return True
 
             return False
 
@@ -84,25 +84,37 @@ class DependencyTree:
             node.children = [child.copy() for child in self.children]
             return node
 
-    def __init__(self, element_type=DependencyTreeElement):
-        self.root = None
+    def __init__(self, element_type=DependencyTreeElement, trees=[]):
+        self.roots = []
         self.element_type = element_type
+        for tree in trees:
+            self.roots += [root.copy() for root in tree.roots]
+
         self._update()
 
-    def push(self, value):
+    def push(self, value: Any, allow_multi_root: bool = False):
+        """ Add a value to this dependency tree.
+
+        Adding a value already present in the tree does not modify the tree. 
+        
+        Args:
+            value: value to add.
+            allow_multi_root: if `True`, allow the value to spawn an 
+                              additional root if needed.
+                
+        """
         element = self.element_type(value)
         node = DependencyTree._Node(element)
-        if self.root is None:
-            self.root = node
-        else:
-            self.root.push(node)
+        
+        added = False
+        for root in self.roots:
+            added |= root.push(node)
+
+        if len(self.roots) == 0 or (not added and allow_multi_root):
+            self.roots.append(node)
 
         # Recompute leaves.
         self._update()
-        if element in self.leaves_elements:
-            return node
-
-        return None
 
     def pop(self, value):
         if value not in self.leaves_values:
@@ -113,9 +125,14 @@ class DependencyTree:
                 if child.element.value == value:
                     node.children.remove(child)
 
-        self._postorder(self.root, _visit)
-        if self.root.element.value == value:
-            self.root = None
+        root_to_remove = [] 
+        for i, root in enumerate(self.roots):
+            self._postorder(root, _visit)
+            if root.element.value == value:
+                root_to_remove.append(i)
+        
+        for i in root_to_remove[::-1]:
+            del self.roots[i]
 
         # Recompute leaves.
         self._update()
@@ -128,25 +145,37 @@ class DependencyTree:
 
     def _update(self):
         self._leaves_values = []
-        self._leaves_elements = set()
+        self._leaves_elements = []
 
         def _visit(node):
             if len(node.children) == 0:
-                self._leaves_elements.add(node.element)
+                self._leaves_elements.append(node.element)
                 self._leaves_values.append(node.element.value)
 
-        if self.root is not None:
-            self._postorder(self.root, _visit)
+        for root in self.roots:
+            self._postorder(root, _visit)
 
         self._leaves_values = uniquify(self._leaves_values)
+        self._leaves_elements = uniquify(self._leaves_elements)
 
     def copy(self):
-        tree = DependencyTree(self.element_type)
-        if self.root is not None:
-            tree.root = self.root.copy()
-            tree._update()
-
+        tree = type(self)(element_type=self.element_type)
+        for root in self.roots:
+            tree.roots.append(root.copy())
+        
+        tree._update()
         return tree
+
+    def tolist(self) -> List[Any]:
+        values = []
+
+        def _visit(node):
+            values.append(node.element.value)
+
+        for root in self.roots:
+            self._postorder(root, _visit)
+    
+        return values
 
     @property
     def leaves_elements(self):
@@ -157,7 +186,5 @@ class DependencyTree:
         return self._leaves_values
 
     def __str__(self):
-        if self.root is None:
-            return ""
+        return "\n".join(map(str, self.roots))
 
-        return str(self.root)

--- a/textworld/generator/tests/test_dependency_tree.py
+++ b/textworld/generator/tests/test_dependency_tree.py
@@ -25,21 +25,23 @@ class CustomDependencyTreeElement(DependencyTreeElement):
 
 class TestDependencyTree(unittest.TestCase):
 
-    def test_pop(self):
+    def test_remove(self):
         tree = DependencyTree(element_type=CustomDependencyTreeElement)
         assert len(tree.roots) == 0
-        tree.push("G")
-        tree.pop("G")
+        assert tree.push("G")
+        assert tree.remove("G")
         assert len(tree.roots) == 0
+        assert list(tree) == []
+        assert tree.values == []
 
-        tree.push("G")
-        tree.push("F")
+        assert tree.push("G")
+        assert tree.push("F")
         # Can't pop a non-leaf element.
-        assert_raises(ValueError, tree.pop, "G")
+        assert not tree.remove("G")
         assert len(tree.roots) > 0
 
         assert set(tree.leaves_values) == set("F")
-        tree.pop("F")
+        assert tree.remove("F")
         assert set(tree.leaves_values) == set("G")
 
     def test_push(self):
@@ -69,16 +71,17 @@ class TestDependencyTree(unittest.TestCase):
 
         tree_ = tree.copy()
         tree.push("E")
-        assert tree_.tolist() != tree.tolist()
+        assert tree_.values != tree.values
         assert set(tree.leaves_values) == set(["E", "C"])
 
         # Add the same element twice at the same level doesn't change the tree.
         tree_ = tree.copy()
         tree.push("E")
-        assert tree_.tolist() == tree.tolist()
+        assert tree_.values == tree.values
         assert set(tree.leaves_values) == set(["E", "C"])
-        # Cannot remove a value that hasn't been added to the tree.
-        assert_raises(ValueError, tree.pop, "Z")
+        # Removing a value not associated to a leaf, does not change the tree.
+        assert not tree.remove("Z")
+        assert tree_.values == tree.values
 
         tree.push("A")
         assert set(tree.leaves_values) == set(["A", "C"])

--- a/textworld/generator/tests/test_dependency_tree.py
+++ b/textworld/generator/tests/test_dependency_tree.py
@@ -27,16 +27,16 @@ class TestDependencyTree(unittest.TestCase):
 
     def test_pop(self):
         tree = DependencyTree(element_type=CustomDependencyTreeElement)
-        assert tree.root is None
+        assert len(tree.roots) == 0
         tree.push("G")
         tree.pop("G")
-        assert tree.root is None
+        assert len(tree.roots) == 0
 
         tree.push("G")
         tree.push("F")
         # Can't pop a non-leaf element.
         assert_raises(ValueError, tree.pop, "G")
-        assert tree.root is not None
+        assert len(tree.roots) > 0
 
         assert set(tree.leaves_values) == set("F")
         tree.pop("F")
@@ -44,41 +44,44 @@ class TestDependencyTree(unittest.TestCase):
 
     def test_push(self):
         tree = DependencyTree(element_type=CustomDependencyTreeElement)
-        assert tree.root is None
+        assert len(tree.roots) == 0
         assert set(tree.leaves_values) == set()
 
-        node = tree.push("G")
+        tree.push("G")
         assert set(tree.leaves_values) == set(["G"]), tree.leaves_values
-        assert tree.root.element.value == "G"
-        assert tree.root is node
-        assert len(node.children) == 0
+        assert tree.roots[0].element.value == "G"
+        assert len(tree.roots[0].children) == 0
 
-        node = tree.push("F")
+        tree.push("F")
         assert set(tree.leaves_values) == set(["F"])
 
-        node = tree.push("C")
+        tree.push("C")
+        node = tree.roots[0].children[0].children[0]
         assert set(tree.leaves_values) == set(["C"])
-        assert tree.root.element.value == "G"
+        assert tree.roots[0].element.value == "G"
         assert node.element.value == "C"
-        assert len(tree.root.children) == 1
+        assert len(tree.roots[0].children) == 1
         assert len(node.children) == 0
 
         # Nothing depends on A at the moment.
-        node = tree.push("A")
+        tree.push("A")
         assert set(tree.leaves_values) == set(["C"])
 
-        node = tree.push("E")
+        tree_ = tree.copy()
+        tree.push("E")
+        assert tree_.tolist() != tree.tolist()
         assert set(tree.leaves_values) == set(["E", "C"])
 
         # Add the same element twice at the same level doesn't change the tree.
-        node = tree.push("E")
-        assert node is None
+        tree_ = tree.copy()
+        tree.push("E")
+        assert tree_.tolist() == tree.tolist()
         assert set(tree.leaves_values) == set(["E", "C"])
         # Cannot remove a value that hasn't been added to the tree.
         assert_raises(ValueError, tree.pop, "Z")
 
-        node = tree.push("A")
+        tree.push("A")
         assert set(tree.leaves_values) == set(["A", "C"])
 
-        node = tree.push("B")
+        tree.push("B")
         assert set(tree.leaves_values) == set(["B", "A", "C"])

--- a/textworld/generator/tests/test_game.py
+++ b/textworld/generator/tests/test_game.py
@@ -27,24 +27,38 @@ from textworld.generator.inform7 import gen_commands_from_actions
 from textworld.logic import Proposition
 
 
+
+def _apply_command(command: str, game_progression: GameProgression):
+    """ Apply a text command to a game_progression object.
+    """
+    valid_commands = gen_commands_from_actions(game_progression.valid_actions, game_progression.game.infos)
+
+    for action, cmd in zip(game_progression.valid_actions, valid_commands):
+        if command == cmd:
+            game_progression.update(action)
+            return
+
+    raise ValueError("Not a valid command: {}. Expected: {}".format(command, valid_commands))
+
+
 def test_game_comparison():
     rngs = {}
     rngs['rng_map'] = np.random.RandomState(1)
     rngs['rng_objects'] = np.random.RandomState(2)
     rngs['rng_quest'] = np.random.RandomState(3)
     rngs['rng_grammar'] = np.random.RandomState(4)
-    game1 = make_game(world_size=5, nb_objects=5, quest_length=2, grammar_flags={}, rngs=rngs)
+    game1 = make_game(world_size=5, nb_objects=5, quest_length=2, quest_breadth=2, grammar_flags={}, rngs=rngs)
 
     rngs['rng_map'] = np.random.RandomState(1)
     rngs['rng_objects'] = np.random.RandomState(2)
     rngs['rng_quest'] = np.random.RandomState(3)
     rngs['rng_grammar'] = np.random.RandomState(4)
-    game2 = make_game(world_size=5, nb_objects=5, quest_length=2, grammar_flags={}, rngs=rngs)
+    game2 = make_game(world_size=5, nb_objects=5, quest_length=2, quest_breadth=2, grammar_flags={}, rngs=rngs)
 
     assert game1 == game2  # Test __eq__
     assert game1 in {game2}  # Test __hash__
 
-    game3 = make_game(world_size=5, nb_objects=5, quest_length=2, grammar_flags={}, rngs=rngs)
+    game3 = make_game(world_size=5, nb_objects=5, quest_length=2, quest_breadth=2, grammar_flags={}, rngs=rngs)
     assert game1 != game3
 
 
@@ -53,7 +67,7 @@ def test_game_comparison():
 def test_variable_infos(verbose=False):
     g_rng.set_seed(1234)
     grammar_flags = {"theme": "house", "include_adj": True}
-    game = textworld.generator.make_game(world_size=5, nb_objects=10, quest_length=3, grammar_flags=grammar_flags)
+    game = textworld.generator.make_game(world_size=5, nb_objects=10, quest_length=3, quest_breadth=2, grammar_flags=grammar_flags)
 
     for var_id, var_infos in game.infos.items():
         if var_id not in ["P", "I"]:
@@ -270,7 +284,46 @@ class TestQuestProgression(unittest.TestCase):
         quest.update(self.quest.actions[0])
         assert quest.winning_policy == self.quest.actions[1:]
 
-    def test_cycle_in_winning_policy(cls):
+
+class TestGameProgression(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        M = GameMaker()
+
+        # The goal
+        commands = ["open wooden door", "go west", "take carrot", "go east", "drop carrot"]
+
+        # Create a 'bedroom' room.
+        R1 = M.new_room("bedroom")
+        R2 = M.new_room("kitchen")
+        M.set_player(R2)
+
+        path = M.connect(R1.east, R2.west)
+        path.door = M.new(type='d', name='wooden door')
+        path.door.add_property("closed")
+
+        carrot = M.new(type='f', name='carrot')
+        R1.add(carrot)
+
+        # Add a closed chest in R2.
+        chest = M.new(type='c', name='chest')
+        chest.add_property("open")
+        R2.add(chest)
+
+        cls.quest = M.set_quest_from_commands(commands)
+        cls.game = M.build()
+
+    def test_is_game_completed(self):
+        game_progress = GameProgression(self.game)
+
+        for action in self.quest.actions:
+            assert not game_progress.done
+            game_progress.update(action)
+
+        assert game_progress.done
+
+    def test_cycle_in_winning_policy(self):
         M = GameMaker()
 
         # Create a map.
@@ -302,16 +355,6 @@ class TestQuestProgression(unittest.TestCase):
         M.set_quest_from_commands(commands)
         game = M.build()
         game_progression = GameProgression(game)
-
-        def _apply_command(command, game_progression):
-            valid_commands = gen_commands_from_actions(game_progression.valid_actions, game.infos)
-
-            for action, cmd in zip(game_progression.valid_actions, valid_commands):
-                if command == cmd:
-                    game_progression.update(action)
-                    return
-
-            raise ValueError("Not a valid command: {}. Expected: {}".format(command, valid_commands))
 
         _apply_command("go south", game_progression)
         expected_commands = ["go north"] + commands
@@ -351,15 +394,26 @@ class TestQuestProgression(unittest.TestCase):
         winning_commands = gen_commands_from_actions(game_progression.winning_policy, game.infos)
         assert winning_commands == expected_commands, "{} != {}".format(winning_commands, expected_commands)
 
-
-class TestGameProgression(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
+    def test_game_with_multiple_quests(self):
         M = GameMaker()
 
-        # The goal
-        commands = ["open wooden door", "go west", "take carrot", "go east", "drop carrot"]
+        # The subgoals (needs to be executed in order).
+        # commands = [["open wooden door"],
+        #             ["go west", "take carrot"],
+        #             ["go east", "drop carrot"],
+        #             # Now, the player is back in the kitchen and the wooden door is open.
+        #             ["go west", "take lettuce"],
+        #             ["go east", "drop lettuce"],
+        #             # Now, the player is back in the kitchen, there are a carrot and a lettuce on the floor.
+        #             ["take lettuce"],
+        #             ["take carrot"],
+        #             ["insert carrot into chest"],
+        #             ["insert lettuce into chest", "close chest"]]
+        commands = [["open wooden door", "go west", "take carrot", "go east", "drop carrot"],
+                    # Now, the player is back in the kitchen and the wooden door is open.
+                    ["go west", "take lettuce", "go east", "drop lettuce"],
+                    # Now, the player is back in the kitchen, there are a carrot and a lettuce on the floor.
+                    ["take lettuce", "take carrot", "insert carrot into chest", "insert lettuce into chest", "close chest"]]
 
         # Create a 'bedroom' room.
         R1 = M.new_room("bedroom")
@@ -371,22 +425,72 @@ class TestGameProgression(unittest.TestCase):
         path.door.add_property("closed")
 
         carrot = M.new(type='f', name='carrot')
-        R1.add(carrot)
+        lettuce = M.new(type='f', name='lettuce')
+        R1.add(carrot, lettuce)
 
         # Add a closed chest in R2.
         chest = M.new(type='c', name='chest')
         chest.add_property("open")
         R2.add(chest)
 
-        cls.quest = M.set_quest_from_commands(commands)
-        cls.game = M.build()
+        quest1 = M.new_quest_using_commands(commands[0])
+        quest1.desc = "Fetch the carrot and drop it on the kitchen's ground."
+        quest2 = M.new_quest_using_commands(commands[0] + commands[1])
+        quest2.desc = "Fetch the lettuce and drop it on the kitchen's ground."
+        winning_facts = [M.new_fact("in", lettuce, chest),
+                         M.new_fact("in", carrot, chest),
+                         M.new_fact("closed", chest),]
+        quest3 = M.new_quest_using_commands(commands[0] + commands[1] + commands[2], winning_facts=winning_facts)
+        # quest3 = M.new_quest_using_commands(commands[0] + commands[1] + commands[2])
+        quest3.desc = "Put the lettuce and the carrot into the chest before closing it."
+        
+        M._quests = [quest1, quest2, quest3]
+        assert len(M._quests) == len(commands)
+        game = M.build()
 
-    def test_is_game_completed(self):
-        game_progress = GameProgression(self.game)
+        game_progress = GameProgression(game)
+        assert len(game_progress.quest_progressions) == len(game.quests)
 
-        for action in self.quest.actions:
+        # for i, qp in enumerate(game_progress.quest_progressions):
+        #     print()
+        #     print(qp._tree)
+        #     print(i, [c.name for c in qp.winning_policy])
+
+        # print()
+        # print([c.name for c in game_progress.winning_policy])
+
+        # Following the actions associated to the last quest actually corresponds
+        # to solving the whole game. 
+        for action in game_progress.winning_policy:
             assert not game_progress.done
             game_progress.update(action)
+            # print(action.name, [c.name for c in game_progress.winning_policy])
+            
+        assert game_progress.done
+        assert all(quest_progression.done for quest_progression in game_progress.quest_progressions)
+
+        # Try solving the game by greedily taking the first action from the current winning policy.
+        game_progress = GameProgression(game)
+        while not game_progress.done:
+            action = game_progress.winning_policy[0]
+            game_progress.update(action)
+
+        # Try solving the second quest (i.e. bringing back the lettuce) first.
+        game_progress = GameProgression(game)
+        for command in ["open wooden door", "go west", "take lettuce", "go east", "drop lettuce"]:
+            _apply_command(command, game_progress)
+        
+        assert not game_progress.quest_progressions[0].done
+        assert game_progress.quest_progressions[1].done
+
+        for command in ["go west", "take carrot", "go east", "drop carrot"]:
+            _apply_command(command, game_progress)
+
+        assert game_progress.quest_progressions[0].done
+        assert game_progress.quest_progressions[1].done
+
+        for command in ["take lettuce", "take carrot", "insert carrot into chest", "insert lettuce into chest", "close chest"]:
+            _apply_command(command, game_progress)
 
         assert game_progress.done
 

--- a/textworld/generator/tests/test_logger.py
+++ b/textworld/generator/tests/test_logger.py
@@ -18,7 +18,7 @@ def test_logger():
     for _ in range(10):
         seed = rng.randint(65635)
         g_rng.set_seed(seed)
-        game = textworld.generator.make_game(world_size=5, nb_objects=10, quest_length=3)
+        game = textworld.generator.make_game(world_size=5, nb_objects=10, quest_length=3, quest_breadth=3)
         game_logger.collect(game)
 
     with make_temp_directory(prefix="textworld_tests") as tests_folder:

--- a/textworld/generator/tests/test_text_generation.py
+++ b/textworld/generator/tests/test_text_generation.py
@@ -77,8 +77,10 @@ def test_blend_instructions(verbose=False):
     grammar2 = textworld.generator.make_grammar(flags={"blend_instructions": True},
                                                 rng=np.random.RandomState(42))
 
+    quest.desc = None
     game.change_grammar(grammar1)
     quest1 = quest.copy()
+    quest.desc = None
     game.change_grammar(grammar2)
     quest2 = quest.copy()
     assert len(quest1.desc) > len(quest2.desc)

--- a/textworld/generator/tests/test_text_grammar.py
+++ b/textworld/generator/tests/test_text_grammar.py
@@ -5,12 +5,20 @@
 import unittest
 
 from textworld.generator.text_grammar import Grammar
+from textworld.generator.text_grammar import GrammarFlags
 
 
 class ContainsEveryObjectContainer:
     def __contains__(self, item):
         return True
 
+
+class TestGrammarFlags(unittest.TestCase):
+    def test_serialization(self):
+        flags = GrammarFlags()
+        data = flags.serialize()
+        flags2 = GrammarFlags.deserialize(data)
+        assert flags == flags2
 
 class GrammarTest(unittest.TestCase):
     def test_grammar_eq(self):
@@ -20,7 +28,7 @@ class GrammarTest(unittest.TestCase):
 
     def test_grammar_eq2(self):
         grammar = Grammar()
-        grammar2 = Grammar(flags={'unused': 'flag'})
+        grammar2 = Grammar(flags={'theme': 'something'})
         self.assertNotEqual(grammar, grammar2, "Testing two different grammar files are not equal")
 
     def test_grammar_get_random_expansion_fail(self):

--- a/textworld/generator/text_generation.py
+++ b/textworld/generator/text_generation.py
@@ -6,6 +6,7 @@ import re
 from collections import OrderedDict
 
 from textworld.generator import data
+from textworld.generator.game import Quest
 
 from textworld.generator.text_grammar import Grammar
 from textworld.generator.text_grammar import fix_determinant
@@ -154,6 +155,11 @@ def generate_text_from_grammar(game, grammar: Grammar):
     # Generate the instructions.
     for quest in game.quests:
         assign_description_to_quest(quest, game, grammar, counts, only_last_action, blend_instructions, ambiguous_instructions)
+
+    if only_last_action and len(game.quests) > 1:
+        main_quest = Quest(actions=[quest.actions[-1] for quest in game.quests])
+        assign_description_to_quest(main_quest, game, grammar, counts, False, blend_instructions, ambiguous_instructions)
+        game.objective = main_quest.desc
 
     return game
 

--- a/textworld/helpers.py
+++ b/textworld/helpers.py
@@ -119,7 +119,7 @@ def play(game_file: str, agent: Optional[Agent] = None, max_nb_steps: int = 1000
         print(msg)
 
 
-def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2,
+def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2, quest_breadth: int = 1,
          grammar_flags: Mapping = {}, seed: int = None,
          games_dir: str = "./gen_games/") -> Tuple[str, Game]:
     """ Makes a text-based game.
@@ -128,6 +128,7 @@ def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2,
         world_size: Number of rooms in the world.
         nb_objects: Number of objects in the world.
         quest_length: Minimum number of actions the quest requires to be completed.
+        quest_breadth: Control how nonlinear a quest can be (1: linear).
         grammar_flags: Grammar options.
         seed: Random seed for the game generation process.
         games_dir: Path to the directory where the game will be saved.
@@ -137,6 +138,6 @@ def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2,
     """
     g_rng.set_seed(seed)
     game_name = "game_{}".format(seed)
-    game = make_game(world_size, nb_objects, quest_length, grammar_flags)
+    game = make_game(world_size, nb_objects, quest_length, quest_breadth, grammar_flags)
     game_file = compile_game(game, game_name, games_folder=games_dir, force_recompile=True)
     return game_file, game

--- a/textworld/render/render.py
+++ b/textworld/render/render.py
@@ -215,7 +215,6 @@ def load_state(world: World, game_infos: Optional[Dict[str, EntityInfo]] = None,
             edges.append((room.name, target.name, room.doors.get(exit)))
             # temp_viz(nodes, edges, pos, color=[world.player_room.name])
 
-    pos = {game_infos[k].name: v for k, v in pos.items()}
 
     rooms = {}
     player_room = world.player_room
@@ -226,6 +225,8 @@ def load_state(world: World, game_infos: Optional[Dict[str, EntityInfo]] = None,
             if v.name is None:
                 v.name = k
 
+    pos = {game_infos[k].name: v for k, v in pos.items()}
+    
     for room in world.rooms:
         rooms[room.id] = GraphRoom(game_infos[room.id].name, room)
 

--- a/textworld/render/render.py
+++ b/textworld/render/render.py
@@ -222,7 +222,6 @@ def load_state(world: World, game_infos: Optional[Dict[str, EntityInfo]] = None,
     if game_infos is None:
         new_game = Game(world, [])
         game_infos = new_game.infos
-        game_infos["objective"] = new_game.quests[0].desc
         for k, v in game_infos.items():
             if v.name is None:
                 v.name = k
@@ -354,9 +353,7 @@ def visualize(world: Union[Game, State, GlulxGameState, World],
     if isinstance(world, Game):
         game = world
         state = load_state(game.world, game.infos)
-        state["objective"] = ""
-        if len(game.quests) > 0:
-            state["objective"] = game.quests[0].desc
+        state["objective"] = game.objective
     elif isinstance(world, GlulxGameState):
         state = load_state_from_game_state(game_state=world)
     elif isinstance(world, World):


### PR DESCRIPTION
This PR adds support for subquests/multi-quests. Here are the highlights:

- It adds the necessary Inform7 code to give points when subquests get completed.
- Can now track multiple quests at the same time, meaning we can still provide intermediate rewards when the agent is on the right path.
- It adds the option to specify the quest-breadth (i.e. nb of subquests) when generating games automatically.
- When text generation option `--only-last-action` is True and there is more than one subquest, the generated text objective describes each subquest's last action in order.

NB: this PR is based on top of #29.  