### PR TITLE
data/logic: Don't duplicate the Inform 7 at() predicate

### DIFF
--- a/textworld/generator/data/logic/room.twl
+++ b/textworld/generator/data/logic/room.twl
@@ -58,9 +58,7 @@ type r {
 
         predicates {
             at(P, r) :: "The player is in {r}";
-            at(s, r) :: "The {s} is in {r}";
-            at(c, r) :: "The {c} is in {r}";
-            at(o, r) :: "The {o} is in {r}";
+            at(t, r) :: "The {t} is in {r}";
 
             north_of(r, r') :: "The {r} is mapped north of {r'}";
             south_of(r, r') :: "The {r} is mapped south of {r'}";


### PR DESCRIPTION
Fixes #33, though we may need to allow these conflicts, taking the more
specific definition, for more interesting uses of multiple inheritance/
attributes.