### PR TITLE
Adding support for subquests in the Inform7 code.

### DIFF
--- a/scripts/tw-make
+++ b/scripts/tw-make
@@ -46,6 +46,8 @@ def parse_args():
                                help="Nb. of objects in the world.")
     custom_parser.add_argument("--quest-length", type=int, default=5, metavar="LENGTH",
                                help="Minimum nb. of actions the quest requires to be completed.")
+    custom_parser.add_argument("--quest-breadth", type=int, default=3, metavar="BREADTH",
+                               help="Control how non-linear a quest can be.")
 
     challenge_parser = subparsers.add_parser("challenge", parents=[general_parser],
                                              help='Generate a game for one of the challenges.')
@@ -72,7 +74,7 @@ if __name__ == "__main__":
     }
 
     if args.subcommand == "custom":
-        game_file, game = textworld.make(args.world_size, args.nb_objects, args.quest_length, grammar_flags,
+        game_file, game = textworld.make(args.world_size, args.nb_objects, args.quest_length, args.quest_breadth, grammar_flags,
                                          seed=args.seed, games_dir=args.output)
 
     elif args.subcommand == "challenge":
@@ -87,7 +89,7 @@ if __name__ == "__main__":
 
     print("Game generated: {}".format(game_file))
     if args.verbose:
-        print(game.quests[0].desc)
+        print(game.objective)
 
     if args.view:
         textworld.render.visualize(game, interactive=True)

--- a/scripts/tw-stats
+++ b/scripts/tw-stats
@@ -38,7 +38,7 @@ if __name__ == "__main__":
             continue
 
         if len(game.quests) > 0:
-            objectives[game_filename] = game.quests[0].desc
+            objectives[game_filename] = game.objective
 
         names |= set(info.name for info in game.infos.values() if info.name is not None)
         game_logger.collect(game)

--- a/tests/test_make_game.py
+++ b/tests/test_make_game.py
@@ -11,11 +11,11 @@ def test_making_game_with_names_to_exclude():
     g_rng.set_seed(42)
 
     with make_temp_directory(prefix="test_render_wrapper") as tmpdir:
-        game_file1, game1 = textworld.make(2, 20, 3, {"names_to_exclude": []},
+        game_file1, game1 = textworld.make(2, 20, 3, 3, {"names_to_exclude": []},
                                            seed=123, games_dir=tmpdir)
 
         game1_objects_names = [info.name for info in game1.infos.values() if info.name is not None]
-        game_file2, game2 = textworld.make(2, 20, 3, {"names_to_exclude": game1_objects_names},
+        game_file2, game2 = textworld.make(2, 20, 3, 3, {"names_to_exclude": game1_objects_names},
                                            seed=123, games_dir=tmpdir)
         game2_objects_names = [info.name for info in game2.infos.values() if info.name is not None]
         assert len(set(game1_objects_names) & set(game2_objects_names)) == 0
@@ -24,8 +24,8 @@ def test_making_game_with_names_to_exclude():
 def test_making_game_is_reproducible_with_seed():
     grammar_flags = {}
     with make_temp_directory(prefix="test_render_wrapper") as tmpdir:
-        game_file1, game1 = textworld.make(2, 20, 3, grammar_flags, seed=123, games_dir=tmpdir)
-        game_file2, game2 = textworld.make(2, 20, 3, grammar_flags, seed=123, games_dir=tmpdir)
+        game_file1, game1 = textworld.make(2, 20, 3, 3, grammar_flags, seed=123, games_dir=tmpdir)
+        game_file2, game2 = textworld.make(2, 20, 3, 3, grammar_flags, seed=123, games_dir=tmpdir)
         assert game_file1 == game_file2
         assert game1 == game2
         # Make sure they are not the same Python objects.

--- a/tests/test_play_generated_games.py
+++ b/tests/test_play_generated_games.py
@@ -16,12 +16,13 @@ def test_play_generated_games():
         # Sample game specs.
         world_size = rng.randint(1, 10)
         nb_objects = rng.randint(0, 20)
-        quest_length = rng.randint(1, 10)
+        quest_length = rng.randint(2, 5)
+        quest_breadth = rng.randint(3, 7)
         game_seed = rng.randint(0, 65365)
         grammar_flags = {}  # Default grammar.
 
         with make_temp_directory(prefix="test_play_generated_games") as tmpdir:
-            game_file, game = textworld.make(world_size, nb_objects, quest_length, grammar_flags,
+            game_file, game = textworld.make(world_size, nb_objects, quest_length, quest_breadth, grammar_flags,
                                              seed=game_seed, games_dir=tmpdir)
 
             # Solve the game using WalkthroughAgent.

--- a/tests/test_textworld.py
+++ b/tests/test_textworld.py
@@ -58,7 +58,7 @@ class TestIntegration(unittest.TestCase):
         agent = textworld.agents.WalkthroughAgent()
         env = textworld.start(self.game_file)
         env.activate_state_tracking()
-        commands = self.game.quests[0].commands
+        commands = self.game.main_quest.commands
         agent.reset(env)
         game_state = env.reset()
 

--- a/tests/test_tw-play.py
+++ b/tests/test_tw-play.py
@@ -7,9 +7,9 @@ import textworld
 from textworld.utils import make_temp_directory
 
 
-def test_making_a_custom_game():                                             
-    with make_temp_directory(prefix="test_tw-play") as tmpdir:    
-        game_file, _ = textworld.make(5, 10, 5, {}, seed=1234, games_dir=tmpdir)
+def test_playing_a_game():
+    with make_temp_directory(prefix="test_tw-play") as tmpdir:
+        game_file, _ = textworld.make(5, 10, 5, 4, {}, seed=1234, games_dir=tmpdir)
 
         command = ["tw-play", "--max-steps", "100", "--mode", "random", game_file]
         assert check_call(command) == 0

--- a/textworld/agents/walkthrough.py
+++ b/textworld/agents/walkthrough.py
@@ -26,7 +26,7 @@ class WalkthroughAgent(Agent):
             raise NameError(msg)
 
         # Load command from the generated game.
-        self._commands = iter(env.game.quests[0].commands)
+        self._commands = iter(env.game.main_quest.commands)
 
     def act(self, game_state, reward, done):
         try:

--- a/textworld/envs/glulx/git_glulx_ml.py
+++ b/textworld/envs/glulx/git_glulx_ml.py
@@ -152,6 +152,7 @@ class GlulxGameState(textworld.GameState):
         self._state_tracking = state_tracking
         self._compute_intermediate_reward = compute_intermediate_reward and len(game.quests) > 0
         self._objective = game.objective
+        self._score = 0
         self._max_score = sum(quest.reward for quest in game.quests)
 
     def view(self) -> "GlulxGameState":
@@ -320,14 +321,18 @@ class GlulxGameState(textworld.GameState):
     @property
     def score(self):
         if not hasattr(self, "_score"):
-            output = self._raw
-            if not self.game_ended:
-                output = self._env._send("score")
+            # Check if there was any Inform7 events.
+            if self._feedback == self._raw:
+                self._score = self.previous_state.score
+            else:
+                output = self._raw
+                if not self.game_ended:
+                    output = self._env._send("score")
 
-            match = re.search("scored (?P<score>[0-9]+) out of a possible (?P<max_score>[0-9]+),", output)
-            self._score = 0
-            if match:
-                self._score = int(match.groupdict()["score"])
+                match = re.search("scored (?P<score>[0-9]+) out of a possible (?P<max_score>[0-9]+),", output)
+                self._score = 0
+                if match:
+                    self._score = int(match.groupdict()["score"])
 
         return self._score
 

--- a/textworld/envs/wrappers/tests/test_viewer.py
+++ b/textworld/envs/wrappers/tests/test_viewer.py
@@ -17,7 +17,7 @@ def test_html_viewer():
     num_items = 10
     g_rng.set_seed(1234)
     grammar_flags = {"theme": "house", "include_adj": True}
-    game = textworld.generator.make_game(world_size=num_nodes, nb_objects=num_items, quest_length=3, grammar_flags=grammar_flags)
+    game = textworld.generator.make_game(world_size=num_nodes, nb_objects=num_items, quest_length=3, quest_breadth=1, grammar_flags=grammar_flags)
 
     game_name = "test_html_viewer_wrapper"
     with make_temp_directory(prefix=game_name) as tmpdir:

--- a/textworld/generator/data/logic/door.twl
+++ b/textworld/generator/data/logic/door.twl
@@ -34,7 +34,13 @@ type d : t {
         link3 :: link(r, d, r') & link(r, d', r') -> fail();
 
         # There cannot be more than four doors in a room.
-        dr2 :: link(r, d1: d, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        too_many_doors :: link(r, d1: d, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        
+        # There cannot be more than four doors in a room.
+        dr1 :: free(r, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr2 :: free(r, r1: r) & free(r, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr3 :: free(r, r1: r) & free(r, r2: r) & free(r, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr4 :: free(r, r1: r) & free(r, r2: r) & free(r, r3: r) & free(r, r4: r) & link(r, d5: d, r5: r) -> fail();
 
         free1 :: link(r, d, r') & free(r, r') & closed(d) -> fail();
         free2 :: link(r, d, r') & free(r, r') & locked(d) -> fail();

--- a/textworld/generator/data/text_grammars/house_instruction.twg
+++ b/textworld/generator/data/text_grammars/house_instruction.twg
@@ -112,7 +112,7 @@ action_seperator_go/north: #afterhave# gone north, ;#emptyinstruction1#;#emptyin
 action_seperator_go/east: #afterhave# gone east, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
 action_seperator_go/west: #afterhave# gone west, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
 action_separator_close: #afterhave# #closed# the #close_open_types#, ; #after# #closing# the #close_open_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
-action_separator_drop: #afterhave# #dropped# #obj_types#, ; #after# #dropping# #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_drop: #afterhave# #dropped# the #obj_types#, ; #after# #dropping# the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
 #Separator Symbols
 afterhave:After you have;Having;Once you have;If you have
 havetaken:taken;got;picked up

--- a/textworld/generator/tests/test_game.py
+++ b/textworld/generator/tests/test_game.py
@@ -48,27 +48,25 @@ def test_game_comparison():
     rngs['rng_objects'] = np.random.RandomState(2)
     rngs['rng_quest'] = np.random.RandomState(3)
     rngs['rng_grammar'] = np.random.RandomState(4)
-    game1 = make_game(world_size=5, nb_objects=5, quest_length=2, grammar_flags={}, rngs=rngs)
+    game1 = make_game(world_size=5, nb_objects=5, quest_length=2, quest_breadth=2, grammar_flags={}, rngs=rngs)
 
     rngs['rng_map'] = np.random.RandomState(1)
     rngs['rng_objects'] = np.random.RandomState(2)
     rngs['rng_quest'] = np.random.RandomState(3)
     rngs['rng_grammar'] = np.random.RandomState(4)
-    game2 = make_game(world_size=5, nb_objects=5, quest_length=2, grammar_flags={}, rngs=rngs)
+    game2 = make_game(world_size=5, nb_objects=5, quest_length=2, quest_breadth=2, grammar_flags={}, rngs=rngs)
 
     assert game1 == game2  # Test __eq__
     assert game1 in {game2}  # Test __hash__
 
-    game3 = make_game(world_size=5, nb_objects=5, quest_length=2, grammar_flags={}, rngs=rngs)
+    game3 = make_game(world_size=5, nb_objects=5, quest_length=2, quest_breadth=2, grammar_flags={}, rngs=rngs)
     assert game1 != game3
-
-
 
 
 def test_variable_infos(verbose=False):
     g_rng.set_seed(1234)
     grammar_flags = {"theme": "house", "include_adj": True}
-    game = textworld.generator.make_game(world_size=5, nb_objects=10, quest_length=3, grammar_flags=grammar_flags)
+    game = textworld.generator.make_game(world_size=5, nb_objects=10, quest_length=3, quest_breadth=2, grammar_flags=grammar_flags)
 
     for var_id, var_infos in game.infos.items():
         if var_id not in ["P", "I"]:

--- a/textworld/generator/tests/test_logger.py
+++ b/textworld/generator/tests/test_logger.py
@@ -18,7 +18,7 @@ def test_logger():
     for _ in range(10):
         seed = rng.randint(65635)
         g_rng.set_seed(seed)
-        game = textworld.generator.make_game(world_size=5, nb_objects=10, quest_length=3)
+        game = textworld.generator.make_game(world_size=5, nb_objects=10, quest_length=3, quest_breadth=3)
         game_logger.collect(game)
 
     with make_temp_directory(prefix="textworld_tests") as tests_folder:

--- a/textworld/generator/tests/test_text_generation.py
+++ b/textworld/generator/tests/test_text_generation.py
@@ -77,8 +77,10 @@ def test_blend_instructions(verbose=False):
     grammar2 = textworld.generator.make_grammar(flags={"blend_instructions": True},
                                                 rng=np.random.RandomState(42))
 
+    quest.desc = None
     game.change_grammar(grammar1)
     quest1 = quest.copy()
+    quest.desc = None
     game.change_grammar(grammar2)
     quest2 = quest.copy()
     assert len(quest1.desc) > len(quest2.desc)

--- a/textworld/generator/tests/test_text_grammar.py
+++ b/textworld/generator/tests/test_text_grammar.py
@@ -5,12 +5,20 @@
 import unittest
 
 from textworld.generator.text_grammar import Grammar
+from textworld.generator.text_grammar import GrammarFlags
 
 
 class ContainsEveryObjectContainer:
     def __contains__(self, item):
         return True
 
+
+class TestGrammarFlags(unittest.TestCase):
+    def test_serialization(self):
+        flags = GrammarFlags()
+        data = flags.serialize()
+        flags2 = GrammarFlags.deserialize(data)
+        assert flags == flags2
 
 class GrammarTest(unittest.TestCase):
     def test_grammar_eq(self):
@@ -20,7 +28,7 @@ class GrammarTest(unittest.TestCase):
 
     def test_grammar_eq2(self):
         grammar = Grammar()
-        grammar2 = Grammar(flags={'unused': 'flag'})
+        grammar2 = Grammar(flags={'theme': 'something'})
         self.assertNotEqual(grammar, grammar2, "Testing two different grammar files are not equal")
 
     def test_grammar_get_random_expansion_fail(self):

--- a/textworld/generator/text_generation.py
+++ b/textworld/generator/text_generation.py
@@ -6,6 +6,7 @@ import re
 from collections import OrderedDict
 
 from textworld.generator import data
+from textworld.generator.game import Quest
 
 from textworld.generator.text_grammar import Grammar
 from textworld.generator.text_grammar import fix_determinant
@@ -21,7 +22,7 @@ class CountOrderedDict(OrderedDict):
         return super().__getitem__(item)
 
 
-def assign_new_matching_names(obj1_infos, obj2_infos, grammar, include_adj, exclude=[]):
+def assign_new_matching_names(obj1_infos, obj2_infos, grammar, exclude=[]):
     tag = "#({}<->{})_match#".format(obj1_infos.type, obj2_infos.type)
     if not grammar.has_tag(tag):
         return False
@@ -31,8 +32,8 @@ def assign_new_matching_names(obj1_infos, obj2_infos, grammar, include_adj, excl
         result = grammar.expand(tag)
         first, second = result.split("<->")  # Matching arguments are separated by '<->'.
 
-        name1, adj1, noun1 = grammar.split_name_adj_noun(first.strip(), include_adj)
-        name2, adj2, noun2 = grammar.split_name_adj_noun(second.strip(), include_adj)
+        name1, adj1, noun1 = grammar.split_name_adj_noun(first.strip(), grammar.flags.include_adj)
+        name2, adj2, noun2 = grammar.split_name_adj_noun(second.strip(), grammar.flags.include_adj)
         if name1 not in exclude and name2 not in exclude and name1 != name2:
             found_matching_names = True
             break
@@ -52,7 +53,7 @@ def assign_new_matching_names(obj1_infos, obj2_infos, grammar, include_adj, excl
     return True
 
 
-def assign_name_to_object(obj, grammar, game_infos, include_adj):
+def assign_name_to_object(obj, grammar, game_infos):
     """
     Assign a name to an object (if needed).
     """
@@ -66,20 +67,19 @@ def assign_name_to_object(obj, grammar, game_infos, include_adj):
     # Check if the object should match another one (i.e. same adjective).
     if obj.matching_entity_id is not None:
         other_obj_infos = game_infos[obj.matching_entity_id]
-        success = assign_new_matching_names(obj_infos, other_obj_infos, grammar, include_adj, exclude)
+        success = assign_new_matching_names(obj_infos, other_obj_infos, grammar, exclude)
         if success:
             return
 
         # Try swapping the objects around i.e. match(o2, o1).
-        success = assign_new_matching_names(other_obj_infos, obj_infos, grammar, include_adj, exclude)
+        success = assign_new_matching_names(other_obj_infos, obj_infos, grammar, exclude)
         if success:
             return
 
         # TODO: Should we enforce it?
         # Fall back on generating unmatching object name.
 
-    values = grammar.generate_name(obj.type, room_type=obj_infos.room_type,
-                                   include_adj=include_adj, exclude=exclude)
+    values = grammar.generate_name(obj.type, room_type=obj_infos.room_type, exclude=exclude)
     obj_infos.name, obj_infos.adj, obj_infos.noun = values
     grammar.used_names.add(obj_infos.name)
 
@@ -103,19 +103,13 @@ def assign_description_to_object(obj, grammar, game_infos):
 
 
 def generate_text_from_grammar(game, grammar: Grammar):
-    include_adj = grammar.flags.get("include_adj", False)
-    only_last_action = grammar.flags.get("only_last_action", False)
-    blend_instructions = grammar.flags.get("blend_instructions", False)
-    blend_descriptions = grammar.flags.get("blend_descriptions", False)
-    ambiguous_instructions = grammar.flags.get("ambiguous_instructions", False)
-
     # Assign a specific room type and name to our rooms
     for room in game.world.rooms:
         # First, generate a unique roomtype and name from the grammar
         if game.infos[room.id].room_type is None and grammar.has_tag("#room_type#"):
             game.infos[room.id].room_type = grammar.expand("#room_type#")
 
-        assign_name_to_object(room, grammar, game.infos, include_adj)
+        assign_name_to_object(room, grammar, game.infos)
 
         # Next, assure objects contained in a room must have the same room type
         for obj in game.world.get_all_objects_in(room):
@@ -127,38 +121,35 @@ def generate_text_from_grammar(game, grammar: Grammar):
         if game.infos[obj.id].room_type is None and grammar.has_tag("#room_type#"):
             game.infos[obj.id].room_type = grammar.expand("#room_type#")
 
-    # We have to "count" all the adj/noun/types in the world
-    # This is important for using "unique" but abstracted references to objects
-    counts = OrderedDict()
-    counts["adj"] = CountOrderedDict()
-    counts["noun"] = CountOrderedDict()
-    counts["type"] = CountOrderedDict()
-
     # Assign name and description to objects.
     for obj in game.world.objects:
         if obj.type in ["I", "P"]:
             continue
 
-        obj_infos = game.infos[obj.id]
-        assign_name_to_object(obj, grammar, game.infos, include_adj)
+        assign_name_to_object(obj, grammar, game.infos)
         assign_description_to_object(obj, grammar, game.infos)
-
-        counts['adj'][obj_infos.adj] += 1
-        counts['noun'][obj_infos.noun] += 1
-        counts['type'][obj.type] += 1
 
     # Generate the room descriptions.
     for room in game.world.rooms:
-        assign_description_to_room(room, game, grammar, blend_descriptions)
+        if game.infos[room.id].desc is None:  # Skip rooms which already have a description.
+            game.infos[room.id].desc = assign_description_to_room(room, game, grammar)
 
     # Generate the instructions.
     for quest in game.quests:
-        assign_description_to_quest(quest, game, grammar, counts, only_last_action, blend_instructions, ambiguous_instructions)
+        if quest.desc is None:  # Skip quests which already have a description.
+            quest.desc = assign_description_to_quest(quest, game, grammar)
+
+    if grammar.flags.only_last_action and len(game.quests) > 1:
+        main_quest = Quest(actions=[quest.actions[-1] for quest in game.quests])
+        only_last_action_bkp = grammar.flags.only_last_action
+        grammar.flags.only_last_action = False
+        game.objective = assign_description_to_quest(main_quest, game, grammar)
+        grammar.flags.only_last_action = only_last_action_bkp
 
     return game
 
 
-def assign_description_to_room(room, game, grammar, blend_descriptions):
+def assign_description_to_room(room, game, grammar):
     """
     Assign a descripton to a room.
     """
@@ -188,7 +179,7 @@ def assign_description_to_room(room, game, grammar, blend_descriptions):
         obj_infos = game.infos[obj.id]
         adj, noun = obj_infos.adj, obj_infos.noun
 
-        if blend_descriptions:
+        if grammar.flags.blend_descriptions:
             found = False
             for type in ["noun", "adj"]:
                 group_filt = []
@@ -248,7 +239,7 @@ def assign_description_to_room(room, game, grammar, blend_descriptions):
 
     exits_desc = []
     # Describing exits with door.
-    if blend_descriptions and len(exits_with_closed_door) > 1:
+    if grammar.flags.blend_descriptions and len(exits_with_closed_door) > 1:
         dirs, door_objs = zip(*exits_with_closed_door)
         e_desc = grammar.expand("#room_desc_doors_closed#")
         e_desc = replace_num(e_desc, len(door_objs))
@@ -263,7 +254,7 @@ def assign_description_to_room(room, game, grammar, blend_descriptions):
             d_desc = d_desc.replace("(dir)", dir_)
             exits_desc.append(d_desc)
 
-    if blend_descriptions and len(exits_with_open_door) > 1:
+    if grammar.flags.blend_descriptions and len(exits_with_open_door) > 1:
         dirs, door_objs = zip(*exits_with_open_door)
         e_desc = grammar.expand("#room_desc_doors_open#")
         e_desc = replace_num(e_desc, len(door_objs))
@@ -279,7 +270,7 @@ def assign_description_to_room(room, game, grammar, blend_descriptions):
             exits_desc.append(d_desc)
 
     # Describing exits without door.
-    if blend_descriptions and len(exits_without_door) > 1:
+    if grammar.flags.blend_descriptions and len(exits_without_door) > 1:
         e_desc = grammar.expand("#room_desc_exits#").replace("(dir)", list_to_string(exits_without_door, False))
         e_desc = repl_sing_plur(e_desc, len(exits_without_door))
         exits_desc.append(e_desc)
@@ -291,7 +282,7 @@ def assign_description_to_room(room, game, grammar, blend_descriptions):
     room_desc += " ".join(exits_desc)
 
     # Finally, set the description
-    game.infos[room.id].desc = fix_determinant(room_desc)
+    return fix_determinant(room_desc)
 
 
 class MergeAction:
@@ -308,7 +299,7 @@ class MergeAction:
         self.end = None
 
 
-def generate_instruction(action, grammar, game_infos, world, counts, ambiguous_instructions):
+def generate_instruction(action, grammar, game_infos, world, counts):
     """
     Generate text instruction for a specific action.
     """
@@ -360,7 +351,7 @@ def generate_instruction(action, grammar, game_infos, world, counts, ambiguous_i
             obj = world.find_object_by_id(var.name)
             obj_infos = game_infos[obj.id]
 
-            if ambiguous_instructions:
+            if grammar.flags.ambiguous_instructions:
                 assert False, "not tested"
                 choices = []
 
@@ -393,29 +384,46 @@ def generate_instruction(action, grammar, game_infos, world, counts, ambiguous_i
     return desc, separator
 
 
-def assign_description_to_quest(quest, game, grammar, counts, only_last_action, blend_instructions, ambiguous_instructions):
+def assign_description_to_quest(quest, game, grammar):
     """
     Assign a descripton to a quest.
     """
+    # We have to "count" all the adj/noun/types in the world
+    # This is important for using "unique" but abstracted references to objects
+    counts = OrderedDict()
+    counts["adj"] = CountOrderedDict()
+    counts["noun"] = CountOrderedDict()
+    counts["type"] = CountOrderedDict()
+
+    # Assign name and description to objects.
+    for obj in game.world.objects:
+        if obj.type in ["I", "P"]:
+            continue
+
+        obj_infos = game.infos[obj.id]
+        counts['adj'][obj_infos.adj] += 1
+        counts['noun'][obj_infos.noun] += 1
+        counts['type'][obj.type] += 1
+
     if len(quest.actions) == 0:
         # We don't need to say anything if the quest is empty
-        quest.desc = "Choose your own adventure!"
+        quest_desc = "Choose your own adventure!"
     else:
         # Generate a description for either the last, or all commands
-        if only_last_action:
-            actions_desc, _ = generate_instruction(quest.actions[-1], grammar, game.infos, game.world, counts, ambiguous_instructions)
+        if grammar.flags.only_last_action:
+            actions_desc, _ = generate_instruction(quest.actions[-1], grammar, game.infos, game.world, counts)
             only_one_action = True
         else:
             actions_desc = ""
             # Decide if we blend instructions together or not
-            if blend_instructions:
+            if grammar.flags.blend_instructions:
                 instructions = get_action_chains(quest.actions, grammar, game.infos)
             else:
                 instructions = quest.actions
 
             only_one_action = len(instructions) < 2
             for c in instructions:
-                desc, separator = generate_instruction(c, grammar, game.infos, game.world, counts, ambiguous_instructions)
+                desc, separator = generate_instruction(c, grammar, game.infos, game.world, counts)
                 actions_desc += desc
                 if c != instructions[-1] and len(separator) > 0:
                     actions_desc += separator
@@ -428,7 +436,9 @@ def assign_description_to_quest(quest, game, grammar, counts, only_last_action, 
             quest_tag = grammar.get_random_expansion("#quest#")
             quest_tag = quest_tag.replace("(list_of_actions)", actions_desc.strip())
 
-        quest.desc = grammar.expand(quest_tag)
+        quest_desc = grammar.expand(quest_tag)
+
+    return quest_desc
 
 
 def get_action_chains(actions, grammar, game_infos):

--- a/textworld/helpers.py
+++ b/textworld/helpers.py
@@ -119,7 +119,7 @@ def play(game_file: str, agent: Optional[Agent] = None, max_nb_steps: int = 1000
         print(msg)
 
 
-def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2,
+def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2, quest_breadth: int = 1,
          grammar_flags: Mapping = {}, seed: int = None,
          games_dir: str = "./gen_games/") -> Tuple[str, Game]:
     """ Makes a text-based game.
@@ -128,6 +128,7 @@ def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2,
         world_size: Number of rooms in the world.
         nb_objects: Number of objects in the world.
         quest_length: Minimum number of actions the quest requires to be completed.
+        quest_breadth: Control how nonlinear a quest can be (1: linear).
         grammar_flags: Grammar options.
         seed: Random seed for the game generation process.
         games_dir: Path to the directory where the game will be saved.
@@ -137,6 +138,6 @@ def make(world_size: int = 1, nb_objects: int = 5, quest_length: int = 2,
     """
     g_rng.set_seed(seed)
     game_name = "game_{}".format(seed)
-    game = make_game(world_size, nb_objects, quest_length, grammar_flags)
+    game = make_game(world_size, nb_objects, quest_length, quest_breadth, grammar_flags)
     game_file = compile_game(game, game_name, games_folder=games_dir, force_recompile=True)
     return game_file, game

--- a/textworld/render/render.py
+++ b/textworld/render/render.py
@@ -215,18 +215,18 @@ def load_state(world: World, game_infos: Optional[Dict[str, EntityInfo]] = None,
             edges.append((room.name, target.name, room.doors.get(exit)))
             # temp_viz(nodes, edges, pos, color=[world.player_room.name])
 
-    pos = {game_infos[k].name: v for k, v in pos.items()}
 
     rooms = {}
     player_room = world.player_room
     if game_infos is None:
         new_game = Game(world, [])
         game_infos = new_game.infos
-        game_infos["objective"] = new_game.quests[0].desc
         for k, v in game_infos.items():
             if v.name is None:
                 v.name = k
 
+    pos = {game_infos[k].name: v for k, v in pos.items()}
+    
     for room in world.rooms:
         rooms[room.id] = GraphRoom(game_infos[room.id].name, room)
 
@@ -354,9 +354,7 @@ def visualize(world: Union[Game, State, GlulxGameState, World],
     if isinstance(world, Game):
         game = world
         state = load_state(game.world, game.infos)
-        state["objective"] = ""
-        if len(game.quests) > 0:
-            state["objective"] = game.quests[0].desc
+        state["objective"] = game.objective
     elif isinstance(world, GlulxGameState):
         state = load_state_from_game_state(game_state=world)
     elif isinstance(world, World):


### PR DESCRIPTION
This PR follows #42 and contains the second and final modification that will bring support to generate games with multiple subquests. It supersedes the rest of PR #30.

This PR adds support for subquests for different parts of the framework.

- Inform7 code: adds code for checking the winning conditions of the different subquests, when all conditions are being met increase the score by some amount defined by the `reward` attribute of `Quest` objects.
- Text generation: makes the text generation for quest description more flexible. 
- `Game`: The objective of the game is now stored in the `Game` objects. It is generated from the `main_quest` (a `Quest` instance) which is created by merging all the subquest dependency trees and extracting a winning policy from the resulting `ActionDependencyTree` object.
- Unit tests: some tests needed to be adapted to include the `max/min_breadth` information. Also, adds more tests for testing the new code.  