### PR TITLE
Enable optional extra information

### DIFF
--- a/textworld/envs/wrappers/filter.py
+++ b/textworld/envs/wrappers/filter.py
@@ -143,6 +143,12 @@ class Filter(Wrapper):
             self.activate_state_tracking()
             self.compute_intermediate_reward()
 
+        if self.options.description:
+            self._wrapped_env.enable_extra_info("description")
+
+        if self.options.inventory:
+            self._wrapped_env.enable_extra_info("inventory")
+
         game_state = super().reset()
         ob = game_state.feedback
         infos = self._get_requested_infos(game_state)

--- a/textworld/envs/wrappers/viewer.py
+++ b/textworld/envs/wrappers/viewer.py
@@ -32,6 +32,7 @@ class HtmlViewer(Wrapper):
 
         # Rendering requires state tracking.
         self.activate_state_tracking()
+        self._wrapped_env.enable_extra_info("inventory")
 
     def _stop_server(self) -> None:
         """

--- a/textworld/generator/inform7/world2inform7.py
+++ b/textworld/generator/inform7/world2inform7.py
@@ -642,6 +642,16 @@ class Inform7Game:
                 try printing the entire state;
 
         Every turn:
+            if extra description command option is true:
+                say "<description>";
+                try looking;
+                say "</description>";
+            if extra inventory command option is true:
+                say "<inventory>";
+                try taking inventory;
+                say "</inventory>";
+            if extra score command option is true:
+                say "<score>[line break][score][line break]</score>";
             if print state option is true:
                 try printing the entire state;
 
@@ -725,6 +735,48 @@ class Inform7Game:
             Understand "take everything" as taking all.
             Understand "get everything" as taking all.
             Understand "pick up everything" as taking all.
+
+        """)
+
+        # Special command to issue "look" command at every step.
+        source += textwrap.dedent("""\
+        The extra description command option is a truth state that varies.
+        The extra description command option is usually false.
+
+        Turning on the extra description command option is an action applying to nothing.
+        Carry out turning on the extra description command option:
+            Decrease turn count by 1;
+            Now the extra description command option is true.
+
+        Understand "tw-extra-infos description" as turning on the extra description command option.
+
+        """)
+
+        # Special command to issue "inventory" command at every step.
+        source += textwrap.dedent("""\
+        The extra inventory command option is a truth state that varies.
+        The extra inventory command option is usually false.
+
+        Turning on the extra inventory command option is an action applying to nothing.
+        Carry out turning on the extra inventory command option:
+            Decrease turn count by 1;
+            Now the extra inventory command option is true.
+
+        Understand "tw-extra-infos inventory" as turning on the extra inventory command option.
+
+        """)
+
+        # Special command to issue "score" command at every step.
+        source += textwrap.dedent("""\
+        The extra score command option is a truth state that varies.
+        The extra score command option is usually false.
+
+        Turning on the extra score command option is an action applying to nothing.
+        Carry out turning on the extra score command option:
+            Decrease turn count by 1;
+            Now the extra score command option is true.
+
+        Understand "tw-extra-infos score" as turning on the extra score command option.
 
         """)
 


### PR DESCRIPTION
This PR adds the option to enable extra information to be fetched from the game (e.g. room's description, inventory, score) at every time step in the game.

By default, when state tracking is not enabled,`env.enable_ extra_info('score')` is used.

EDIT:
When there is a question in Inform7, the next string sent to the game will be considered as the answer. This PR makes sure that asking for extra information (like `description`, `inventory` or `score`) before answering the question works as expected.