### PR TITLE
Fix issue with text generation related to the match predicate.

### DIFF
--- a/textworld/generator/text_generation.py
+++ b/textworld/generator/text_generation.py
@@ -98,7 +98,7 @@ def assign_description_to_object(obj, grammar, game_infos):
         game_infos[obj.id].desc = expand_clean_replace(desc_tag, grammar, obj, game_infos)
 
     # If we have an openable object, append an additional description
-    if obj.type in ["c", "d"]:
+    if data.get_types().is_descendant_of(obj.type, ["c", "d"]):
         game_infos[obj.id].desc += grammar.expand(" #openable_desc#")
 
 

--- a/textworld/generator/world.py
+++ b/textworld/generator/world.py
@@ -117,10 +117,6 @@ class WorldEntity(Variable):
             self.properties.append(fact.name)
 
         self.related_facts.append(fact)
-        if fact.name == "match":
-            self.matching_entity_id = fact.arguments[1].name
-            if fact.arguments[1].name == self.name:
-                self.matching_entity_id = fact.arguments[0].name
 
     def get_attributes(self) -> List[Proposition]:
         return self.related_facts
@@ -319,6 +315,11 @@ class World:
 
             obj = self._get_entity(fact.arguments[0])
             obj.add_related_fact(fact)
+
+            if fact.name == "match":
+                other_obj = self._get_entity(fact.arguments[1])
+                obj.matching_entity_id = fact.arguments[1].name
+                other_obj.matching_entity_id = fact.arguments[0].name
 
             if fact.name in ["in", "on", "at"]:
                 holder = self._get_entity(fact.arguments[1])


### PR DESCRIPTION
Small issue during text generation. E.g.

```
-= Bedchamber =-                                                                                       
Look at you, bigshot, walking into a bedchamber like it isn't some huge deal. Hey, want to see a locker? Look over there, a locker. You see a closed microwave. There is an open portal leading east. There is an unblocked exit to the north.                                                            
                                                           
> x locker
The suitcase looks well-built. You can't see inside it because the lid's in your way.
```
The name of the container examined is not the same as the one appearing in the room description (`suitcase` vs. `locker`).