### PR TITLE
Increase Jericho sub-sub-version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ urwid>=2.0.1
 more_itertools
 tatsu>=4.2.5
 hashids>=1.2.0
-jericho>=1.1.0
+jericho>=1.1.1
 
 # For visualization
 pybars3>=0.9.3


### PR DESCRIPTION
According to @mhauskn Jericho version 1.1&#8203;**.1** needs to be used to get proper MacOS support.