### PR TITLE
Support multiple winning failing conditions for quest

### DIFF
--- a/tests/test_textworld.py
+++ b/tests/test_textworld.py
@@ -125,7 +125,7 @@ def test_playing_generated_games():
                     msg = "Finished before playing `max_steps` steps because of command '{}'.".format(command)
                     if game_state.has_won:
                         msg += " (winning)"
-                        assert len(game_state._game_progression.winning_policy) == 0
+                        assert game_state._game_progression.winning_policy is None
 
                     if game_state.has_lost:
                         msg += " (losing)"

--- a/textworld/challenges/treasure_hunter.py
+++ b/textworld/challenges/treasure_hunter.py
@@ -28,7 +28,8 @@ from typing import Mapping, Union, Dict, Optional
 import textworld
 from textworld.utils import uniquify
 from textworld.logic import Variable, Proposition
-from textworld.generator import Quest, World
+from textworld.generator import World
+from textworld.generator.game import Quest, Event
 from textworld.generator.data import KnowledgeBase
 from textworld.generator.vtypes import get_new
 from textworld.challenges.utils import get_seeds_for_game_generation
@@ -192,8 +193,9 @@ def make_game(mode: str, options: GameOptions) -> textworld.Game:
 
     # Add objects needed for the quest.
     world.state = chain.initial_state
-    quest = Quest(chain.actions)
-    quest.set_failing_conditions([Proposition("in", [wrong_obj, world.inventory])])
+    event = Event(chain.actions)
+    quest = Quest(win_events=[event],
+                  fail_events=[Event(conditions={Proposition("in", [wrong_obj, world.inventory])})])
 
     grammar = textworld.generator.make_grammar(options.grammar, rng=rng_grammar)
     game = textworld.generator.make_game_with(world, [quest], grammar)

--- a/textworld/envs/glulx/tests/test_git_glulx_ml.py
+++ b/textworld/envs/glulx/tests/test_git_glulx_ml.py
@@ -18,6 +18,7 @@ from textworld import testing
 from textworld.generator.maker import GameMaker
 from textworld.utils import make_temp_directory
 from textworld.generator import data
+from textworld.generator.game import Quest, Event
 from textworld.generator.graph_networks import DIRECTIONS
 from textworld.envs.glulx.git_glulx_ml import StateTrackingIsRequiredError
 from textworld.envs.glulx.git_glulx_ml import OraclePolicyIsRequiredError
@@ -27,9 +28,6 @@ from textworld.envs.glulx.git_glulx_ml import GameNotRunningError
 
 def build_test_game():
     M = GameMaker()
-
-    # The goal
-    commands = ["go east", "insert carrot into chest"]
 
     # Create a 'bedroom' room.
     R1 = M.new_room("bedroom")
@@ -48,12 +46,13 @@ def build_test_game():
     chest.add_property("open")
     R2.add(chest)
 
+    commands = ["go east", "insert carrot into chest"]
     quest1 = M.new_quest_using_commands(commands)
     quest1.reward = 2
-    quest2 = M.new_quest_using_commands(commands + ["close chest"])
-    quest2.set_winning_conditions([M.new_fact("in", carrot, chest),
-                                   M.new_fact("closed", chest)])
-    M._quests = [quest1, quest2]
+    commands = ["go east", "insert carrot into chest", "close chest"]
+    event = M.new_event_using_commands(commands)
+    quest2 = Quest(win_events=[event])
+    M.quests = [quest1, quest2]
     game = M.build()
     return game
 

--- a/textworld/envs/zmachine/tests/test_jericho.py
+++ b/textworld/envs/zmachine/tests/test_jericho.py
@@ -19,6 +19,7 @@ from textworld import testing
 from textworld.generator.maker import GameMaker
 from textworld.utils import make_temp_directory
 from textworld.generator import data
+from textworld.generator.game import Quest, Event
 from textworld.generator.graph_networks import DIRECTIONS
 from textworld.envs.glulx.git_glulx_ml import StateTrackingIsRequiredError
 from textworld.envs.glulx.git_glulx_ml import OraclePolicyIsRequiredError
@@ -51,11 +52,13 @@ def build_test_game():
 
     quest1 = M.new_quest_using_commands(commands)
     quest1.reward = 2
-    quest2 = M.new_quest_using_commands(commands + ["close chest"])
-    quest2.set_winning_conditions([M.new_fact("in", carrot, chest),
-                                   M.new_fact("closed", chest)])
-    quest2.set_failing_conditions([M.new_fact("eaten", carrot)])
-    M._quests = [quest1, quest2]
+
+    commands = ["go east", "insert carrot into chest", "close chest"]
+    event = M.new_event_using_commands(commands)
+    quest2 = Quest(win_events=[event],
+                   fail_events=[Event(conditions={M.new_fact("eaten", carrot)})])
+
+    M.quests = [quest1, quest2]
     game = M.build()
     return game
 

--- a/textworld/generator/__init__.py
+++ b/textworld/generator/__init__.py
@@ -14,7 +14,7 @@ from numpy.random import RandomState
 from textworld import g_rng
 from textworld.utils import maybe_mkdir, str2bool
 from textworld.generator.chaining import ChainingOptions, sample_quest
-from textworld.generator.game import Game, Quest, World, GameOptions
+from textworld.generator.game import Game, Quest, Event, World, GameOptions
 from textworld.generator.graph_networks import create_map, create_small_map
 from textworld.generator.text_generation import generate_text_from_grammar
 
@@ -127,7 +127,8 @@ def make_quest(world, quest_length, rng=None, rules_per_depth=(), backward=False
     options.rng = rng
     options.rules_per_depth = rules_per_depth
     chain = sample_quest(state, options)
-    return Quest(chain.actions)
+    event = Event(chain.actions)
+    return Quest(win_events=[event])
 
 
 def make_grammar(options: Mapping = {}, rng: Optional[RandomState] = None) -> Grammar:
@@ -178,11 +179,11 @@ def make_game(options: GameOptions) -> Game:
     subquests = []
     for i in range(1, len(chain.nodes)):
         if chain.nodes[i].breadth != chain.nodes[i - 1].breadth:
-            quest = Quest(chain.actions[:i])
-            subquests.append(quest)
+            event = Event(chain.actions[:i])
+            subquests.append(Quest(win_events=[event]))
 
-    quest = Quest(chain.actions)
-    subquests.append(quest)
+    event = Event(chain.actions)
+    subquests.append(Quest(win_events=[event]))
 
     # Set the initial state required for the quest.
     world.state = chain.initial_state

--- a/textworld/generator/chaining.py
+++ b/textworld/generator/chaining.py
@@ -429,13 +429,9 @@ class _Chainer:
 
         constraints = state.all_applicable_actions(self.constraints)
         for constraint in constraints:
-            if state.is_applicable(constraint):
-                # Optimistically delay copying the state
-                copy = state.copy()
-                copy.apply(constraint)
-
-                if copy.is_fact(fail):
-                    return False
+            copy = state.apply_on_copy(constraint)
+            if copy and copy.is_fact(fail):
+                return False
 
         return True
 

--- a/textworld/generator/data/logic/door.twl
+++ b/textworld/generator/data/logic/door.twl
@@ -35,7 +35,7 @@ type d : t {
 
         # There cannot be more than four doors in a room.
         too_many_doors :: link(r, d1: d, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
-        
+
         # There cannot be more than four doors in a room.
         dr1 :: free(r, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
         dr2 :: free(r, r1: r) & free(r, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
@@ -56,6 +56,7 @@ type d : t {
             open(d) :: "The {d} is open";
             closed(d) :: "The {d} is closed";
             locked(d) :: "The {d} is locked";
+            link(r, d, r') :: "";  # No equivalent in Inform7.
         }
 
         commands {

--- a/textworld/generator/data/logic/room.twl
+++ b/textworld/generator/data/logic/room.twl
@@ -59,6 +59,7 @@ type r {
         predicates {
             at(P, r) :: "The player is in {r}";
             at(t, r) :: "The {t} is in {r}";
+            free(r, r') :: "";  # No equivalent in Inform7.
 
             north_of(r, r') :: "The {r} is mapped north of {r'}";
             south_of(r, r') :: "The {r} is mapped south of {r'}";

--- a/textworld/generator/dependency_tree.py
+++ b/textworld/generator/dependency_tree.py
@@ -132,7 +132,7 @@ class DependencyTree:
         self._update()  # Recompute leaves.
         return added
 
-    def remove(self, value: Any) -> None:
+    def remove(self, value: Any) -> bool:
         """ Remove all leaves having the given value.
 
         The value to remove needs to belong to at least one leaf in this tree.
@@ -184,6 +184,10 @@ class DependencyTree:
     def __iter__(self) -> Iterable["DependencyTree._Node"]:
         for root in self.roots:
             yield from list(root)
+
+    @property
+    def empty(self) -> bool:
+        return len(self.roots) == 0
 
     @property
     def values(self) -> List[Any]:

--- a/textworld/generator/logger.py
+++ b/textworld/generator/logger.py
@@ -73,20 +73,21 @@ class GameLogger:
         # Collect distribution of nb. of commands.
         update_bincount(self.dist_quest_count, len(game.quests))
 
-        # Collect distribution of command's types.
+        # Collect distribution of commands leading to winning events.
         for quest in game.quests:
-            actions = quest.actions
             self.quests.add(quest.desc)
-            update_bincount(self.dist_quest_length_count, len(actions))
+            for event in quest.win_events:
+                actions = event.actions
+                update_bincount(self.dist_quest_length_count, len(actions))
 
-            for action in actions:
-                action_name = action.name
-                if self.group_actions:
-                    action_name = action_name.split("-")[0].split("/")[0]
+                for action in actions:
+                    action_name = action.name
+                    if self.group_actions:
+                        action_name = action_name.split("-")[0].split("/")[0]
 
-                self.dist_cmd_type[action_name] += 1
+                    self.dist_cmd_type[action_name] += 1
 
-            self.dist_final_cmd_type[action_name] += 1
+                self.dist_final_cmd_type[action_name] += 1
 
         # Collect distribution of object's types.
         dist_obj_type = defaultdict(lambda: 0)

--- a/textworld/generator/tests/test_game.py
+++ b/textworld/generator/tests/test_game.py
@@ -3,6 +3,8 @@
 
 
 import unittest
+import textwrap
+from typing import Iterable
 
 import numpy as np
 import numpy.testing as npt
@@ -19,25 +21,29 @@ from textworld.generator import make_small_map, make_grammar, make_game_with
 from textworld.generator.chaining import ChainingOptions, sample_quest
 from textworld.logic import Action, State
 
-from textworld.generator.game import Quest, Game
-from textworld.generator.game import QuestProgression, GameProgression
-from textworld.generator.game import UnderspecifiedQuestError
+from textworld.generator.game import Quest, Game, Event
+from textworld.generator.game import QuestProgression, GameProgression, EventProgression
+from textworld.generator.game import UnderspecifiedEventError, UnderspecifiedQuestError
 from textworld.generator.game import ActionDependencyTree, ActionDependencyTreeElement
 from textworld.generator.inform7 import Inform7Game
 
 from textworld.logic import Proposition
 
 
-def _apply_command(command: str, game_progression: GameProgression, inform7: Inform7Game) -> None:
-    """ Apply a text command to a game_progression object.
-    """
-    valid_commands = inform7.gen_commands_from_actions(game_progression.valid_actions)
-    for action, cmd in zip(game_progression.valid_actions, valid_commands):
+def _find_action(command: str, actions: Iterable[Action], inform7: Inform7Game) -> None:
+    """ Apply a text command to a game_progression object. """
+    commands = inform7.gen_commands_from_actions(actions)
+    for action, cmd in zip(actions, commands):
         if command == cmd:
-            game_progression.update(action)
-            return
+            return action
 
-    raise ValueError("Not a valid command: {}. Expected: {}".format(command, valid_commands))
+    raise ValueError("No action found matching command: {}.".format(command))
+
+
+def _apply_command(command: str, game_progression: GameProgression, inform7: Inform7Game) -> None:
+    """ Apply a text command to a game_progression object. """
+    action = _find_action(command, game_progression.valid_actions, inform7)
+    game_progression.update(action)
 
 
 def test_game_comparison():
@@ -84,6 +90,56 @@ def test_variable_infos(verbose=False):
             assert var_infos.desc is not None
 
 
+class TestEvent(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        M = GameMaker()
+
+        # The goal
+        commands = ["take carrot", "insert carrot into chest"]
+
+        R1 = M.new_room("room")
+        M.set_player(R1)
+
+        carrot = M.new(type='f', name='carrot')
+        R1.add(carrot)
+
+        # Add a closed chest in R2.
+        chest = M.new(type='c', name='chest')
+        chest.add_property("open")
+        R1.add(chest)
+
+        cls.event = M.new_event_using_commands(commands)
+        cls.actions = cls.event.actions
+        cls.conditions = {M.new_fact("in", carrot, chest)}
+
+    def test_init(self):
+        event = Event(self.actions)
+        assert event.actions == self.actions
+        assert event.condition == self.event.condition
+        assert event.condition.preconditions == self.actions[-1].postconditions
+        assert set(event.condition.preconditions).issuperset(self.conditions)
+
+        event = Event(conditions=self.conditions)
+        assert len(event.actions) == 0
+        assert set(event.condition.preconditions) == set(self.conditions)
+
+        npt.assert_raises(UnderspecifiedEventError, Event, actions=[])
+        npt.assert_raises(UnderspecifiedEventError, Event, actions=[], conditions=[])
+        npt.assert_raises(UnderspecifiedEventError, Event, conditions=[])
+
+    def test_serialization(self):
+        data = self.event.serialize()
+        event = Event.deserialize(data)
+        assert event == self.event
+
+    def test_copy(self):
+        event = self.event.copy()
+        assert event == self.event
+        assert id(event) != id(self.event)
+
+
 class TestQuest(unittest.TestCase):
 
     @classmethod
@@ -110,35 +166,47 @@ class TestQuest(unittest.TestCase):
         chest.add_property("open")
         R2.add(chest)
 
-        cls.failing_conditions = (Proposition("eaten", [carrot.var]),)
-        cls.quest = M.set_quest_from_commands(commands)
-        cls.quest.set_failing_conditions(cls.failing_conditions)
+        cls.eventA = M.new_event_using_commands(commands)
+        cls.eventB = Event(conditions={M.new_fact("at", carrot, R1),
+                                            M.new_fact("closed", path.door)})
+        cls.eventC = Event(conditions={M.new_fact("eaten", carrot)})
+        cls.eventD = Event(conditions={M.new_fact("closed", chest),
+                                            M.new_fact("closed", path.door)})
+        cls.quest = Quest(win_events=[cls.eventA, cls.eventB],
+                          fail_events=[cls.eventC, cls.eventD],
+                          reward=2)
+
+        M.quests = [cls.quest]
         cls.game = M.build()
+        cls.inform7 = Inform7Game(cls.game)
 
-    def test_quest_creation(self):
-        quest = Quest(self.quest.actions)
-        assert quest.actions == self.quest.actions
-        assert quest.win_action == self.quest.win_action
-        assert quest.win_action.preconditions == self.quest.actions[-1].postconditions
-        assert quest.fail_action is None
+    def test_init(self):
+        npt.assert_raises(UnderspecifiedQuestError, Quest)
 
-        quest = Quest(winning_conditions=self.quest.actions[-1].postconditions)
-        assert len(quest.actions) == 0
-        assert quest.win_action == self.quest.win_action
-        assert quest.fail_action is None
+        quest = Quest(win_events=[self.eventA, self.eventB])
+        assert len(quest.fail_events) == 0
 
-        npt.assert_raises(UnderspecifiedQuestError, Quest, actions=[], winning_conditions=None)
+        quest = Quest(fail_events=[self.eventC, self.eventD])
+        assert len(quest.win_events) == 0
 
-        quest = Quest(self.quest.actions, failing_conditions=self.failing_conditions)
-        assert quest.fail_action == self.quest.fail_action
-        assert quest.fail_action.preconditions == self.failing_conditions
+        quest = Quest(win_events=[self.eventA],
+                      fail_events=[self.eventC, self.eventD])
 
-    def test_quest_serialization(self):
+        assert len(quest.win_events) > 0
+        assert len(quest.fail_events) > 0
+
+    def test_serialization(self):
         data = self.quest.serialize()
         quest = Quest.deserialize(data)
         assert quest == self.quest
+        assert id(quest) != id(self.quest)
 
-    def test_win_action(self):
+    def test_copy(self):
+        quest = self.quest.copy()
+        assert quest == self.quest
+        assert id(quest) != id(self.quest)
+
+    def test_generating_quests(self):
         g_rng.set_seed(2018)
         map_ = make_small_map(n_rooms=5, possible_door_states=["open"])
         world = World.from_map(map_)
@@ -155,43 +223,97 @@ class TestQuest(unittest.TestCase):
 
                 # Build the quest by providing the actions.
                 actions = chain.actions
-                if len(actions) != max_depth:
-                    print(chain)
                 assert len(actions) == max_depth, rule.name
-                quest = Quest(actions)
+                quest = Quest(win_events=[Event(actions)])
                 tmp_world = World.from_facts(chain.initial_state.facts)
 
                 state = tmp_world.state
                 for action in actions:
-                    assert not state.is_applicable(quest.win_action)
+                    assert not quest.is_winning(state)
                     state.apply(action)
 
-                assert state.is_applicable(quest.win_action)
+                assert quest.is_winning(state)
 
                 # Build the quest by only providing the winning conditions.
-                quest = Quest(actions=None, winning_conditions=actions[-1].postconditions)
+                quest = Quest(win_events=[Event(conditions=actions[-1].postconditions)])
                 tmp_world = World.from_facts(chain.initial_state.facts)
 
                 state = tmp_world.state
                 for action in actions:
-                    assert not state.is_applicable(quest.win_action)
+                    assert not quest.is_winning(state)
                     state.apply(action)
 
-                assert state.is_applicable(quest.win_action)
+                assert quest.is_winning(state)
 
-    def test_fail_action(self):
+    def test_win_actions(self):
         state = self.game.world.state.copy()
-        assert not state.is_applicable(self.quest.fail_action)
+        for action in self.quest.win_events[0].actions:
+            assert not self.quest.is_winning(state)
+            state.apply(action)
+
+        assert self.quest.is_winning(state)
+
+        # Test alternative way of winning,
+        # i.e. dropping the carrot and closing the door.
+        state = self.game.world.state.copy()
+        actions = list(state.all_applicable_actions(self.game.kb.rules.values(),
+                                                    self.game.kb.types.constants_mapping))
+
+        drop_carrot = _find_action("drop carrot", actions, self.inform7)
+        close_door = _find_action("close wooden door", actions, self.inform7)
+
+        state = self.game.world.state.copy()
+        assert state.apply(drop_carrot)
+        assert not self.quest.is_winning(state)
+        assert state.apply(close_door)
+        assert self.quest.is_winning(state)
+
+        # Or the other way around.
+        state = self.game.world.state.copy()
+        assert state.apply(close_door)
+        assert not self.quest.is_winning(state)
+        assert state.apply(drop_carrot)
+        assert self.quest.is_winning(state)
+
+    def test_fail_actions(self):
+        state = self.game.world.state.copy()
+        assert not self.quest.is_failing(state)
 
         actions = list(state.all_applicable_actions(self.game.kb.rules.values(),
                                                     self.game.kb.types.constants_mapping))
+        eat_carrot = _find_action("eat carrot", actions, self.inform7)
+        go_east = _find_action("go east", actions, self.inform7)
+
         for action in actions:
             state = self.game.world.state.copy()
             state.apply(action)
-            if action.name.startswith("eat"):
-                assert state.is_applicable(self.quest.fail_action)
-            else:
-                assert not state.is_applicable(self.quest.fail_action)
+            # Only the `eat carrot` should fail.
+            assert self.quest.is_failing(state) == (action == eat_carrot)
+
+        state = self.game.world.state.copy()
+        state.apply(go_east)  # Move to the kitchen.
+        actions = list(state.all_applicable_actions(self.game.kb.rules.values(),
+                                                    self.game.kb.types.constants_mapping))
+        close_door = _find_action("close wooden door", actions, self.inform7)
+        close_chest = _find_action("close chest", actions, self.inform7)
+
+        # Only closing the door doesn't fail the quest.
+        state_ = state.apply_on_copy(close_door)
+        assert not self.quest.is_failing(state_)
+
+        # Only closing the chest doesn't fail the quest.
+        state_ = state.apply_on_copy(close_chest)
+        assert not self.quest.is_failing(state_)
+
+        # Closing the chest, then the door should fail the quest.
+        state_ = state.apply_on_copy(close_chest)
+        state_.apply(close_door)
+        assert self.quest.is_failing(state_)
+
+        # Closing the door, then the chest should fail the quest.
+        state_ = state.apply_on_copy(close_door)
+        state_.apply(close_chest)
+        assert self.quest.is_failing(state_)
 
 
 class TestGame(unittest.TestCase):
@@ -247,9 +369,80 @@ class TestGame(unittest.TestCase):
 
     def test_serialization(self):
         data = self.game.serialize()
-        game2 = Game.deserialize(data)
-        assert self.game == game2
-        assert self.game.metadata == game2.metadata
+        game = Game.deserialize(data)
+        assert game == self.game
+        assert id(game) != id(self.game)
+        assert game.metadata == self.game.metadata
+
+    def test_copy(self):
+        game = self.game.copy()
+        assert game == self.game
+        assert id(game) != id(self.game)
+        assert game.metadata == self.game.metadata
+
+
+class TestEventProgression(unittest.TestCase):
+
+
+    @classmethod
+    def setUpClass(cls):
+        M = GameMaker()
+
+        # The goal
+        commands = ["take carrot", "insert carrot into chest"]
+
+        R1 = M.new_room("room")
+        M.set_player(R1)
+
+        carrot = M.new(type='f', name='carrot')
+        R1.add(carrot)
+
+        # Add a closed chest in R2.
+        chest = M.new(type='c', name='chest')
+        chest.add_property("open")
+        R1.add(chest)
+
+        cls.event = M.new_event_using_commands(commands)
+        cls.actions = cls.event.actions
+        cls.conditions = {M.new_fact("in", carrot, chest)}
+        cls.game = M.build()
+        commands = ["take carrot", "eat carrot"]
+        cls.eating_carrot = M.new_event_using_commands(commands)
+
+    def test_triggering_policy(self):
+        event = EventProgression(self.event, KnowledgeBase.default())
+
+        state = self.game.world.state.copy()
+        expected_actions = self.event.actions
+        for i, action in enumerate(expected_actions):
+            assert event.triggering_policy == expected_actions[i:]
+            assert not event.done
+            assert not event.triggered
+            assert not event.untriggerable
+            state.apply(action)
+            event.update(action=action, state=state)
+
+        assert event.triggering_policy == ()
+        assert event.done
+        assert event.triggered
+        assert not event.untriggerable
+
+    def test_untriggerable(self):
+        event = EventProgression(self.event, KnowledgeBase.default())
+
+        state = self.game.world.state.copy()
+        for action in self.eating_carrot.actions:
+            assert event.triggering_policy != ()
+            assert not event.done
+            assert not event.triggered
+            assert not event.untriggerable
+            state.apply(action)
+            event.update(action=action, state=state)
+
+        assert event.triggering_policy == ()
+        assert event.done
+        assert not event.triggered
+        assert event.untriggerable
 
 
 class TestQuestProgression(unittest.TestCase):
@@ -258,55 +451,106 @@ class TestQuestProgression(unittest.TestCase):
     def setUpClass(cls):
         M = GameMaker()
 
-        # Create a 'bedroom' room.
-        R1 = M.new_room("bedroom")
-        R2 = M.new_room("kitchen")
-        M.set_player(R2)
-
-        path = M.connect(R1.east, R2.west)
-        path.door = M.new(type='d', name='wooden door')
-        path.door.add_property("closed")
+        room = M.new_room("room")
+        M.set_player(room)
 
         carrot = M.new(type='f', name='carrot')
-        R1.add(carrot)
+        lettuce = M.new(type='f', name='lettuce')
+        room.add(carrot)
+        room.add(lettuce)
 
-        # Add a closed chest in R2.
         chest = M.new(type='c', name='chest')
         chest.add_property("open")
-        R2.add(chest)
+        room.add(chest)
 
-        # The goal
-        commands = ["open wooden door", "go west", "take carrot", "go east", "drop carrot"]
-        cls.quest = M.set_quest_from_commands(commands)
+        # The goals
+        commands = ["take carrot", "insert carrot into chest"]
+        cls.eventA = M.new_event_using_commands(commands)
 
-        commands = ["open wooden door", "go west", "take carrot", "eat carrot"]
-        cls.eating_quest = M.new_quest_using_commands(commands)
+        commands = ["take lettuce", "insert lettuce into chest", "close chest"]
+        event = M.new_event_using_commands(commands)
+        cls.eventB = Event(actions=event.actions,
+                                conditions={M.new_fact("in", lettuce, chest),
+                                            M.new_fact("closed", chest)})
 
+        cls.fail_eventA = Event(conditions={M.new_fact("eaten", carrot)})
+        cls.fail_eventB = Event(conditions={M.new_fact("eaten", lettuce)})
+
+        cls.quest = Quest(win_events=[cls.eventA, cls.eventB],
+                          fail_events=[cls.fail_eventA, cls.fail_eventB])
+
+        commands = ["take carrot", "eat carrot"]
+        cls.eating_carrot = M.new_event_using_commands(commands)
+        commands = ["take lettuce", "eat lettuce"]
+        cls.eating_lettuce = M.new_event_using_commands(commands)
+        commands = ["take lettuce", "insert lettuce into chest"]
+
+        M.quests = [cls.quest]
         cls.game = M.build()
 
-    def test_winning_policy(self):
-        quest = QuestProgression(self.quest, KnowledgeBase.default())
-        assert quest.winning_policy == self.quest.actions
-        quest.update(self.quest.actions[0], state=State())
-        assert tuple(quest.winning_policy) == self.quest.actions[1:]
-
-    def test_failing_quest(self):
-        quest = QuestProgression(self.quest, KnowledgeBase.default())
-
-        state = self.game.state.copy()
-        for action in self.eating_quest.actions:
-            state.apply(action)
-            if action.name.startswith("eat"):
-                quest.update(action, state)
-                assert len(quest.winning_policy) == 0
-                assert quest.done
-                assert not quest.completed
-                assert not quest.failed
-                assert quest.unfinishable
-                break
-
+    def _apply_actions_to_quest(self, actions, quest):
+        state = self.game.world.state.copy()
+        for action in actions:
             assert not quest.done
-            assert len(quest.winning_policy) > 0
+            state.apply(action)
+            quest.update(action, state)
+
+        assert quest.done
+        return quest
+
+    def test_completed(self):
+        quest = QuestProgression(self.quest, KnowledgeBase.default())
+        quest = self._apply_actions_to_quest(self.eventA.actions, quest)
+        assert quest.completed
+        assert not quest.failed
+        assert quest.winning_policy is None
+
+        # Alternative winning strategy.
+        quest = QuestProgression(self.quest, KnowledgeBase.default())
+        quest = self._apply_actions_to_quest(self.eventB.actions, quest)
+        assert quest.completed
+        assert not quest.failed
+        assert quest.winning_policy is None
+
+    def test_failed(self):
+        quest = QuestProgression(self.quest, KnowledgeBase.default())
+        quest = self._apply_actions_to_quest(self.eating_carrot.actions, quest)
+        assert not quest.completed
+        assert quest.failed
+        assert quest.winning_policy is None
+
+        quest = QuestProgression(self.quest, KnowledgeBase.default())
+        quest = self._apply_actions_to_quest(self.eating_lettuce.actions, quest)
+        assert not quest.completed
+        assert quest.failed
+        assert quest.winning_policy is None
+
+    def test_winning_policy(self):
+        kb = KnowledgeBase.default()
+        quest = QuestProgression(self.quest, kb)
+        quest = self._apply_actions_to_quest(quest.winning_policy, quest)
+        assert quest.completed
+        assert not quest.failed
+        assert quest.winning_policy is None
+
+        # Winning policy should be the shortest one leading to a winning event.
+        state = self.game.world.state.copy()
+        quest = QuestProgression(self.quest, KnowledgeBase.default())
+        for i, action in enumerate(self.eventB.actions):
+            if i < 2:
+                assert quest.winning_policy == self.eventA.actions
+            else:
+                # After taking the lettuce and putting it in the chest,
+                # QuestB becomes the shortest one to complete.
+                assert quest.winning_policy == self.eventB.actions[i:]
+            assert not quest.done
+            state.apply(action)
+            quest.update(action, state)
+
+        assert quest.done
+        assert quest.completed
+        assert not quest.failed
+        assert quest.winning_policy is None
 
 
 class TestGameProgression(unittest.TestCase):
@@ -315,9 +559,6 @@ class TestGameProgression(unittest.TestCase):
     def setUpClass(cls):
         M = GameMaker()
 
-        # The goal
-        commands = ["open wooden door", "go west", "take carrot", "go east", "drop carrot"]
-
         # Create a 'bedroom' room.
         R1 = M.new_room("bedroom")
         R2 = M.new_room("kitchen")
@@ -328,24 +569,110 @@ class TestGameProgression(unittest.TestCase):
         path.door.add_property("closed")
 
         carrot = M.new(type='f', name='carrot')
+        lettuce = M.new(type='f', name='lettuce')
         R1.add(carrot)
+        R1.add(lettuce)
 
         # Add a closed chest in R2.
         chest = M.new(type='c', name='chest')
         chest.add_property("open")
         R2.add(chest)
 
-        cls.quest = M.set_quest_from_commands(commands)
+        # The goals
+        commands = ["open wooden door", "go west", "take carrot", "go east", "drop carrot"]
+        cls.eventA = M.new_event_using_commands(commands)
+
+        commands = ["open wooden door", "go west", "take lettuce", "go east", "insert lettuce into chest"]
+        cls.eventB = M.new_event_using_commands(commands)
+
+        cls.losing_eventA = Event(conditions={M.new_fact("eaten", carrot)})
+        cls.losing_eventB = Event(conditions={M.new_fact("eaten", lettuce)})
+
+        cls.questA = Quest(win_events=[cls.eventA], fail_events=[cls.losing_eventA])
+        cls.questB = Quest(win_events=[cls.eventB], fail_events=[cls.losing_eventB])
+        cls.questC = Quest(win_events=[], fail_events=[cls.losing_eventA, cls.losing_eventB])
+
+        commands = ["open wooden door", "go west", "take lettuce", "go east", "insert lettuce into chest"]
+        cls.questC = M.new_quest_using_commands(commands)
+
+        commands = ["open wooden door", "go west", "take carrot", "eat carrot"]
+        cls.eating_carrot = M.new_event_using_commands(commands)
+        commands = ["open wooden door", "go west", "take lettuce", "eat lettuce"]
+        cls.eating_lettuce = M.new_event_using_commands(commands)
+        commands = ["open wooden door", "go west", "take lettuce", "go east", "insert lettuce into chest"]
+
+        M.quests = [cls.questA, cls.questB]
         cls.game = M.build()
 
-    def test_is_game_completed(self):
-        game_progress = GameProgression(self.game)
+    def test_completed(self):
+        game = GameProgression(self.game)
+        for action in self.eventA.actions:
+            assert not game.done
+            game.update(action)
 
-        for action in self.quest.actions:
+        assert not game.done
+        remaining_actions = self.eventB.actions[1:]  # skipping "open door".
+        assert game.winning_policy == remaining_actions
+
+        for action in self.eventB.actions:
+            assert not game.done
+            game.update(action)
+
+        assert game.done
+        assert game.completed
+        assert not game.failed
+        assert game.winning_policy is None
+
+    def test_failed(self):
+        game = GameProgression(self.game)
+        for action in self.eating_carrot.actions:
+            assert not game.done
+            game.update(action)
+
+        assert game.done
+        assert not game.completed
+        assert game.failed
+        assert game.winning_policy is None
+
+        game = GameProgression(self.game)
+        for action in self.eating_lettuce.actions:
+            assert not game.done
+            game.update(action)
+
+        assert game.done
+        assert not game.completed
+        assert game.failed
+        assert game.winning_policy is None
+
+        # Completing QuestA but failing quest B.
+        game = GameProgression(self.game)
+        for action in self.eventA.actions:
+            assert not game.done
+            game.update(action)
+
+        assert not game.done
+
+        game = GameProgression(self.game)
+        for action in self.eating_lettuce.actions:
+            assert not game.done
+            game.update(action)
+
+        assert game.done
+        assert not game.completed
+        assert game.failed
+        assert game.winning_policy is None
+
+    def test_winning_policy(self):
+        # Test following the winning policy derived from the quests.
+        game_progress = GameProgression(self.game)
+        for action in game_progress.winning_policy:
             assert not game_progress.done
             game_progress.update(action)
 
         assert game_progress.done
+        assert game_progress.completed
+        assert not game_progress.failed
+        assert game_progress.winning_policy is None
 
     def test_cycle_in_winning_policy(self):
         M = GameMaker()
@@ -455,11 +782,11 @@ class TestGameProgression(unittest.TestCase):
         winning_facts = [M.new_fact("in", lettuce, chest),
                          M.new_fact("in", carrot, chest),
                          M.new_fact("closed", chest),]
-        quest3.set_winning_conditions(winning_facts)
+        quest3.win_events[0].set_conditions(winning_facts)
         quest3.desc = "Put the lettuce and the carrot into the chest before closing it."
 
-        M._quests = [quest1, quest2, quest3]
-        assert len(M._quests) == len(commands)
+        M.quests = [quest1, quest2, quest3]
+        assert len(M.quests) == len(commands)
         game = M.build()
 
         inform7 = Inform7Game(game)
@@ -521,6 +848,7 @@ class TestGameProgression(unittest.TestCase):
         game = M.build()
         game_progress = GameProgression(game)
         assert not game_progress.done
+        assert game_progress.winning_policy is None
 
         # Simulate action that doesn't change the world.
         action = game_progress.valid_actions[0]
@@ -530,7 +858,8 @@ class TestGameProgression(unittest.TestCase):
 
 class TestActionDependencyTree(unittest.TestCase):
 
-    def test_flatten(self):
+    @classmethod
+    def setUpClass(cls):
         action_lock = Action.parse("lock/c :: $at(P, r) & $at(c, r) & $match(k, c) & $in(k, I) & closed(c) -> locked(c)")
         action_close = Action.parse("close/c :: $at(P, r) & $at(c, r) & open(c) -> closed(c)")
         action_insert1 = Action.parse("insert :: $at(P, r) & $at(c, r) & $open(c) & in(o1: o, I) -> in(o1: o, c)")
@@ -547,5 +876,19 @@ class TestActionDependencyTree(unittest.TestCase):
         tree.push(action_insert2)
         tree.push(action_take1)
         tree.push(action_take2)
-        actions = list(a.name for a in tree.flatten())
+        cls.tree = tree
+
+    def test_flatten(self):
+        actions = list(a.name for a in self.tree.flatten())
         assert actions == ['take', 'insert', 'take', 'insert', 'close/c', 'lock/c', 'win'], actions
+
+    def test_str(self):
+        expected = textwrap.dedent("""\
+        win(o1: o, c, o2: o)
+          lock/c(P, r, c, k, I)
+            close/c(P, r, c)
+          insert(P, r, c, o1: o, I)
+            take(P, r, o1: o, I)
+          insert(P, r, c, o2: o, I)
+            take(P, r, o2: o, I)""")
+        assert expected == str(self.tree)

--- a/textworld/logic/__init__.py
+++ b/textworld/logic/__init__.py
@@ -1602,6 +1602,27 @@ class State:
         else:
             return False
 
+    def apply_on_copy(self, action: Action) -> Optional["State"]:
+        """
+        Apply an action to a copy of this state.
+
+        Parameters
+        ----------
+        action :
+            The action to apply.
+
+        Returns
+        -------
+        The copied state after the action has been applied or `None` if action
+        wasn't applicable.
+        """
+        if not self.is_applicable(action):
+            return None
+
+        state = self.copy()
+        state.apply(action)
+        return state
+
     def all_applicable_actions(self, rules: Iterable[Rule], mapping: Mapping[Placeholder, Variable] = None) -> Iterable[Action]:
         """
         Get all the rule instantiations that would be valid actions in this state.


### PR DESCRIPTION
This PR adds support for multiple winning and failing conditions for quests. In order to do that, a new `Event` is introduced to define events that can be triggered when some conditions are satisfied. Each quest has now a set of mutually exclusive winning events and a set of mutually exclusive failing events.

This PR also refactors part of the framework to use those events and adds a bunch of tests.

This PR also adds the method `State.apply_on_copy(action)` as a convenient way of doing:
```python
state.copy()
state.apply(action)
```

~~NB: I'll rebase once #67 is merged.~~