### PR TITLE
Add memoization to GameLogic.parse

### DIFF
--- a/textworld/logic/__init__.py
+++ b/textworld/logic/__init__.py
@@ -3,7 +3,7 @@
 
 
 from collections import Counter, defaultdict, deque, namedtuple
-from functools import total_ordering
+from functools import total_ordering, lru_cache
 import itertools
 import re
 from tatsu.model import NodeWalker
@@ -1401,6 +1401,7 @@ class GameLogic:
                 rules[new_name] = new_rule
 
     @classmethod
+    @lru_cache(maxsize=128, typed=False)
     def parse(cls, document: str) -> "GameLogic":
         result = cls()
         result._parse(document)


### PR DESCRIPTION
This PR speeds up the loading time when loading several games within a same Python instance.

Since #62, the KnowledgeBase (i.e. its "document" representation to be more procise) is saved along with the game itself. This means when loading several games sharing the same KB, we can cache the `GameLogic.parse` result and avoid the costly Tatsu parsing when possible. 

For instance, benchmarking using our two slowest unit tests:
```
time nosetests tests/test_textworld.py:TestIntegration.test_100_sequential_runs tests/test_textworld.py:TestIntegration.test_simultaneous_runs
Before: 1m24s.570s
After: 8.033s
Speedup: ~10.5x
```