### PR TITLE
Add extra information specific to given games

### DIFF
--- a/textworld/envs/glulx/git_glulx_ml.py
+++ b/textworld/envs/glulx/git_glulx_ml.py
@@ -145,6 +145,7 @@ class GlulxGameState(textworld.GameState):
         """
         output = _strip_input_prompt_symbol(output)
         super().init(output)
+        self._game = game
         self._game_progression = GameProgression(game, track_quests=compute_intermediate_reward)
         self._inform7 = Inform7Game(game)
         self._state_tracking = state_tracking
@@ -201,6 +202,7 @@ class GlulxGameState(textworld.GameState):
         game_state._objective = self.objective
         game_state._max_score = self.max_score
         game_state._inform7 = self._inform7
+        game_state._game = self._game
         game_state._game_progression = self._game_progression
         game_state._state_tracking = self._state_tracking
         game_state._compute_intermediate_reward = self._compute_intermediate_reward
@@ -363,7 +365,7 @@ class GlulxGameState(textworld.GameState):
     @property
     def game_infos(self) -> Mapping:
         """ Additional information about the game. """
-        return self._game_progression.game.infos
+        return self._game.infos
 
     @property
     def state(self) -> State:
@@ -389,15 +391,28 @@ class GlulxGameState(textworld.GameState):
                 raise StateTrackingIsRequiredError("admissible_commands")
 
             all_valid_commands = self._inform7.gen_commands_from_actions(self._game_progression.valid_actions)
-            # Add single-word commands.
-            all_valid_commands.append("look")
-            all_valid_commands.append("inventory")
-            # TODO: Manually add 'examine <obj>' given objects in the room?
             # To guarantee the order from one execution to another, we sort the commands.
             # Remove any potential duplicate commands (they would lead to the same result anyway).
             self._admissible_commands = sorted(set(all_valid_commands))
 
         return self._admissible_commands
+
+    @property
+    def command_templates(self):
+        return self._game.command_templates
+
+    @property
+    def verbs(self):
+        return self._game.verbs
+
+    @property
+    def entities(self):
+        return self._game.entity_names
+
+    @property
+    def extras(self):
+        return self._game.extras
+
 
 
 class GitGlulxMLEnvironment(textworld.Environment):

--- a/textworld/envs/glulx/tests/test_git_glulx_ml.py
+++ b/textworld/envs/glulx/tests/test_git_glulx_ml.py
@@ -273,11 +273,20 @@ class TestGlulxGameState(unittest.TestCase):
 
     def test_admissible_commands(self):
         game_state = self.env.reset()
+        # Make sure examine, look and inventory are in the admissible commands.
+        assert "examine carrot" in game_state.admissible_commands
+        assert "examine wooden door" in game_state.admissible_commands
+
         for command in self.game.main_quest.commands:
+            assert "look" in game_state.admissible_commands
+            assert "inventory" in game_state.admissible_commands
             assert command in game_state.admissible_commands
             game_state, _, done = self.env.step(command)
 
         assert done
+        # Can't examine objects that are inside closed containers.
+        assert "examine chest" in game_state.admissible_commands
+        assert "examine carrot" not in game_state.admissible_commands
 
     def test_view(self):
         view = self.game_state.view()

--- a/textworld/generator/__init__.py
+++ b/textworld/generator/__init__.py
@@ -169,7 +169,7 @@ def make_game(options: GameOptions) -> Game:
 
     # Sample a quest.
     chaining_options = options.chaining.copy()
-    chaining_options.rules_per_depth = [options.kb.rules.get_matching("^(?!go.*).*")]
+    chaining_options.rules_per_depth = [options.kb.rules.get_matching("^(?!(go.*|examine.*|look.*|inventory.*)).*")]
     chaining_options.backward = True
     chaining_options.create_variables = True
     chaining_options.rng = rngs['quest']

--- a/textworld/generator/__init__.py
+++ b/textworld/generator/__init__.py
@@ -169,7 +169,9 @@ def make_game(options: GameOptions) -> Game:
 
     # Sample a quest.
     chaining_options = options.chaining.copy()
-    chaining_options.rules_per_depth = [options.kb.rules.get_matching("^(?!(go.*|examine.*|look.*|inventory.*)).*")]
+    # Go, examine, look and inventory shouldn't be used for chaining.
+    exclude = ["go.*", "examine.*", "look.*", "inventory.*"]
+    chaining_options.rules_per_depth = [options.kb.rules.get_matching(".*", exclude=exclude)]
     chaining_options.backward = True
     chaining_options.create_variables = True
     chaining_options.rng = rngs['quest']

--- a/textworld/generator/chaining.py
+++ b/textworld/generator/chaining.py
@@ -104,11 +104,18 @@ class ChainingOptions:
         self.subquests = False
         self.independent_chains = False
         self.create_variables = False
-        self.fixed_mapping = KnowledgeBase.default().types.constants_mapping
+        self.kb = KnowledgeBase.default()
         self.rng = None
-        self.logic = KnowledgeBase.default().logic
         self.rules_per_depth = []
         self.restricted_types = frozenset()
+
+    @property
+    def logic(self) -> GameLogic:
+        return self.kb.logic
+
+    @property
+    def fixed_mapping(self) -> GameLogic:
+        return self.kb.types.constants_mapping
 
     def get_rules(self, depth: int) -> Iterable[Rule]:
         """
@@ -124,7 +131,8 @@ class ChainingOptions:
         if depth < len(self.rules_per_depth):
             return self.rules_per_depth[depth]
         else:
-            return self.logic.rules.values()
+            # Examine, look and inventory shouldn't be used for chaining.
+            return self.kb.rules.get_matching("^(?!(examine.*|look.*|inventory.*)).*")
 
     def check_action(self, state: State, action: Action) -> bool:
         """

--- a/textworld/generator/chaining.py
+++ b/textworld/generator/chaining.py
@@ -132,7 +132,8 @@ class ChainingOptions:
             return self.rules_per_depth[depth]
         else:
             # Examine, look and inventory shouldn't be used for chaining.
-            return self.kb.rules.get_matching("^(?!(examine.*|look.*|inventory.*)).*")
+            exclude = ["examine.*", "look.*", "inventory.*"]
+            return self.kb.rules.get_matching(".*", exclude=exclude)
 
     def check_action(self, state: State, action: Action) -> bool:
         """

--- a/textworld/generator/data/logic/door.twl
+++ b/textworld/generator/data/logic/door.twl
@@ -14,6 +14,8 @@ type d : t {
 
         open/d   :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & closed(d) -> open(d) & free(r, r') & free(r', r);
         close/d  :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & open(d) & free(r, r') & free(r', r) -> closed(d);
+
+        examine/d :: at(P, r) & $link(r, d, r') -> at(P, r);  # Nothing changes.
     }
 
     reverse_rules {
@@ -65,6 +67,8 @@ type d : t {
 
             unlock/d :: "unlock {d} with {k}" :: "unlocking {d} with the {k}";
             lock/d :: "lock {d} with {k}" :: "locking {d} with the {k}";
+
+            examine/d :: "examine {d}" :: "examining {d}";
         }
     }
 }

--- a/textworld/generator/data/logic/inventory.twl
+++ b/textworld/generator/data/logic/inventory.twl
@@ -5,6 +5,8 @@ type I {
     }
 
     rules {
+        inventory :: at(P, r) -> at(P, r);  # Nothing changes.
+
         take :: $at(P, r) & at(o, r) -> in(o, I);
         drop :: $at(P, r) & in(o, I) -> at(o, r);
 
@@ -13,6 +15,10 @@ type I {
 
         take/s :: $at(P, r) & $at(s, r) & on(o, s) -> in(o, I);
         put    :: $at(P, r) & $at(s, r) & in(o, I) -> on(o, s);
+
+        examine/I :: in(o, I) -> in(o, I);  # Nothing changes.
+        examine/s :: at(P, r) & $at(s, r) & $on(o, s) -> at(P, r);  # Nothing changes.
+        examine/c :: at(P, r) & $at(c, r) & $open(c) & $in(o, c) -> at(P, r);  # Nothing changes.
     }
 
     reverse_rules {
@@ -37,6 +43,10 @@ type I {
             put :: "put {o} on {s}" :: "putting the {o} on the {s}";
 
             inventory :: "inventory" :: "taking inventory";
+
+            examine/I :: "examine {o}" :: "examining the {o}";
+            examine/s :: "examine {o}" :: "examining the {o}";
+            examine/c :: "examine {o}" :: "examining the {o}";
         }
     }
 }

--- a/textworld/generator/data/logic/player.twl
+++ b/textworld/generator/data/logic/player.twl
@@ -1,8 +1,11 @@
 # Player
 type P {
+    rules {
+        look :: at(P, r) -> at(P, r);  # Nothing changes.
+    }
+
     inform7 {
         commands {
-            wait :: "wait" :: "waiting";
             look :: "look" :: "looking";
         }
     }

--- a/textworld/generator/data/logic/thing.twl
+++ b/textworld/generator/data/logic/thing.twl
@@ -1,8 +1,16 @@
 # thing
 type t {
+    rules {
+        examine/t :: at(P, r) & $at(t, r) -> at(P, r);
+    }
+
     inform7 {
         type {
             kind :: "thing";
+        }
+
+        commands {
+            examine/t :: "examine {t}" :: "examining the {t}";
         }
     }
 }

--- a/textworld/generator/data/text_grammars/house_instruction.twg
+++ b/textworld/generator/data/text_grammars/house_instruction.twg
@@ -19,6 +19,9 @@ init_syn:in it;inside;placed inside
 into_syn:into;inside
 #actions
 ##actions should start with a verb (ie:ensure, make sure, etc (these could probably just be a tag))
+look:look around in (r).
+examine:examine (o|k|f|d|c|s|t).
+inventory:examine your inventory.
 take:#take_synonym_1# the #obj_types# in the (r).;#take_synonym_1# the #obj_types# from the (r).;#take_synonym_1# the #obj_types# that's in the (r).
 take_synonym_1:take;retrieve;recover;pick up
 take/s:#take_synonym_1# the #obj_types# from the #on_var#.

--- a/textworld/generator/inform7/tests/test_world2inform7.py
+++ b/textworld/generator/inform7/tests/test_world2inform7.py
@@ -52,7 +52,23 @@ def test_quest_winning_condition():
     map_ = make_small_map(n_rooms=5, possible_door_states=["open"])
     world = World.from_map(map_)
 
+    def _rule_to_skip(rule):
+        # Examine, look and inventory shouldn't be used for chaining.
+        if rule.name.startswith("look"):
+            return True
+
+        if rule.name.startswith("inventory"):
+            return True
+
+        if rule.name.startswith("examine"):
+            return True
+
+        return False
+
     for rule in KnowledgeBase.default().rules.values():
+        if _rule_to_skip(rule):
+            continue
+
         options = ChainingOptions()
         options.backward = True
         options.max_depth = 1

--- a/textworld/generator/tests/test_chaining.py
+++ b/textworld/generator/tests/test_chaining.py
@@ -200,6 +200,7 @@ def test_parallel_quests():
             }
         }
     """)
+    kb = KnowledgeBase(logic, "")
 
     state = State([
         Proposition.parse("a(foo)"),
@@ -209,7 +210,7 @@ def test_parallel_quests():
 
     options = ChainingOptions()
     options.backward = True
-    options.logic = logic
+    options.kb = kb
 
     options.max_depth = 3
     options.max_breadth = 1
@@ -285,6 +286,7 @@ def test_parallel_quests_navigation():
             }
         }
     """)
+    kb = KnowledgeBase(logic, "")
 
     state = State([
         Proposition.parse("at(P, r3: r)"),
@@ -292,8 +294,8 @@ def test_parallel_quests_navigation():
         Proposition.parse("free(r1: r, r2: r)"),
     ])
 
-    bake = [logic.rules["bake"]]
-    non_bake = [r for r in logic.rules.values() if r.name != "bake"]
+    bake = [kb.logic.rules["bake"]]
+    non_bake = [r for r in kb.logic.rules.values() if r.name != "bake"]
 
     options = ChainingOptions()
     options.backward = True
@@ -302,7 +304,7 @@ def test_parallel_quests_navigation():
     options.max_depth = 3
     options.min_breadth = 2
     options.max_breadth = 2
-    options.logic = logic
+    options.kb = kb
     options.rules_per_depth = [bake, non_bake, non_bake]
     options.restricted_types = {"P", "r"}
     chains = list(get_chains(state, options))

--- a/textworld/generator/tests/test_grammar.py
+++ b/textworld/generator/tests/test_grammar.py
@@ -77,11 +77,6 @@ def test_propositions():
 
 
 def test_rules():
-    # Make sure the number of basic rules matches the number
-    # of rules in rules.txt
-    basic_rules = [k for k in KnowledgeBase.default().rules.keys() if "-" not in k]
-    assert len(basic_rules) == 19
-
     for rule in KnowledgeBase.default().rules.values():
         infos = rule.serialize()
         loaded_rule = Rule.deserialize(infos)

--- a/textworld/render/render.py
+++ b/textworld/render/render.py
@@ -219,7 +219,7 @@ def load_state(world: World, game_infos: Optional[Dict[str, EntityInfo]] = None,
     rooms = {}
     player_room = world.player_room
     if game_infos is None:
-        new_game = Game(world, [])
+        new_game = Game(world)
         game_infos = new_game.infos
         for k, v in game_infos.items():
             if v.name is None:

--- a/textworld/utils.py
+++ b/textworld/utils.py
@@ -9,6 +9,7 @@ import shutil
 import tempfile
 import contextlib
 from collections import OrderedDict
+from typing import List, Any
 
 import numpy as np
 
@@ -119,11 +120,29 @@ class RegexDict(OrderedDict):
     Adapted from
     https://stackoverflow.com/questions/21024822/python-accessing-dictionary-with-wildcards.
     """
-    def get_matching(self, *regexes):
-        """ Query the dictionary using a regex. """
+    def get_matching(self, *regexes: List[str], exclude: List[str] = []) -> List[Any]:
+        r"""
+        Query the dictionary using one or several regular expressions.
+
+        Arguments:
+            \*regexes: List of regular expressions determining which keys
+                       of this dictionary are relevant to this query.
+            exclude: List of regular expressions determining which keys
+                     of this dictionary should be excluded from this query.
+
+        Returns:
+           The value associated to each relevant (and not excluded) keys.
+
+        """
         matches = []
         for regex in regexes:
             matches += [self[key] for key in self if re.fullmatch(regex, key)]
+
+        to_exclude = []
+        for regex in exclude:
+            to_exclude += [self[key] for key in self if re.fullmatch(regex, key)]
+
+        matches = [m for m in matches if m not in to_exclude]
 
         if len(matches) == 0:
             raise ValueError("No rule matches your regex: {}.".format(regexes))


### PR DESCRIPTION
This PR add a new `extras` attribute to the `Game` objects that can be used to store additional information about a particular game (e.g. the text description of a recipe that needs to be completed). Then, that information will be available via the `GlulxGameState.extras` property.

This PR also makes available the list of verbs, command templates, and entities of a game (all accessible via properties of `GlulxGameState`)

With this PR, instead of manually adding the commands `look` and `inventory` (see [admissible_commands()](https://github.com/Microsoft/TextWorld/compare/master...MarcCote:enh_more_game_infos?expand=1#diff-8feea169a0657bb95d0f88655484c5f2L392)), those are now automatically added when parsing the `.twl` files.

This PR also adds the needed logic code to make relevant `examine <obj>` commands part of the admissible commands.