### PR TITLE
Fix tatsu when installing for the first time in a fresh environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "tatsu >= 4.3.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ networkx>=2
 pyyaml>=3.12
 urwid>=2.0.1
 more_itertools
-tatsu>=4.2.5
+tatsu>=4.3.0
 hashids>=1.2.0
 jericho>=1.1.1
 


### PR DESCRIPTION
pip has been inconsistent about whether dependencies are installed
before setup.sh is run.  Using pyproject.toml convinces pip to always
install it before doing anything else.

C.f. https://www.python.org/dev/peps/pep-0518/