### PR TITLE
Change how extras are added to infos + DOC

### DIFF
--- a/textworld/envs/wrappers/filter.py
+++ b/textworld/envs/wrappers/filter.py
@@ -86,6 +86,26 @@ class EnvInfos:
 class Filter(Wrapper):
     """
     Environment wrapper to filter what information is made available.
+
+    Requested information will be included within the `infos` dictionary
+    returned by `Filter.reset()` and `Filter.step(...)`. To request
+    specific information, create a
+    :py:class:`textworld.EnvInfos <textworld.envs.wrappers.filter.EnvInfos>`
+    and set the appropriate attributes to `True`. Then, instantiate a `Filter`
+    wrapper with the `EnvInfos` object.
+
+    Example:
+        Here is an example of how to request information and retrieve it.
+
+        >>> from textworld import EnvInfos
+        >>> from textworld.envs.wrappers import Filter
+        >>> request_infos = EnvInfos(description=True, inventory=True, extras=["more"])
+        ...
+        >>> env = Filter(env)
+        >>> ob, infos = env.reset()
+        >>> print(infos["description"])
+        >>> print(infos["inventory"])
+        >>> print(infos["extra.more"])
     """
 
     def __init__(self, options: EnvInfos) -> None:
@@ -104,8 +124,8 @@ class Filter(Wrapper):
         infos = {attr: getattr(game_state, attr) for attr in self.options.basics}
 
         if self.options.extras:
-            infos["extras"] = {attr: game_state.extras.get(attr)
-                               for attr in self.options.extras}
+            for attr in self.options.extras:
+                infos["extra.{}".format(attr)] = game_state.extras.get(attr)
 
         return infos
 

--- a/textworld/gym/utils.py
+++ b/textworld/gym/utils.py
@@ -44,7 +44,7 @@ def register_games(game_files: List[str],
         >>> env_id = textworld.gym.register_games([game_file], request_infos)
         >>> env = gym.make(env_id)
         >>> ob, infos = env.reset()
-        >>> print(infos["extras"]["more"])
+        >>> print(infos["extra.more"])
         This is extra information.
 
     """


### PR DESCRIPTION
Extras information will directly be accessible in the `infos` dictionary returned by `env.reset()` and `env.step(command)`.

For instance, requesting `EnvInfos(extras=["name_of_extra"])` would result in `infos["extra.name_of_extra"]`.