### PR TITLE
Tweak Inform7 generated code.

### DIFF
--- a/textworld/generator/game.py
+++ b/textworld/generator/game.py
@@ -270,7 +270,7 @@ class Quest:
 
 class EntityInfo:
     """ Additional information about entities in the game. """
-    __slots__ = ['id', 'type', 'name', 'noun', 'adj', 'desc', 'room_type']
+    __slots__ = ['id', 'type', 'name', 'noun', 'adj', 'desc', 'room_type', 'definite', 'indefinite', 'synonyms']
 
     def __init__(self, id: str, type: str) -> None:
         #: str: Unique name for this entity. It is used when generating
@@ -283,6 +283,12 @@ class EntityInfo:
         self.noun = None
         #: str: The adjective (i.e. descriptive) part of the name, if available.
         self.adj = None
+        #: str: The definite article to use for this entity.
+        self.definite = None
+        #: str: The indefinite article to use for this entity.
+        self.indefinite = None
+        #: List[str]: Alternative names that can be used to refer to this entity.
+        self.synonyms = None
         #: str: Text description displayed when examining this entity in the game.
         self.desc = None
         #: str: Type of the room this entity belongs to. It used to influence
@@ -310,7 +316,7 @@ class EntityInfo:
         """
         info = cls(data["id"], data["type"])
         for slot in cls.__slots__:
-            setattr(info, slot, data[slot])
+            setattr(info, slot, data.get(slot))
 
         return info
 

--- a/textworld/generator/inform7/tests/test_world2inform7.py
+++ b/textworld/generator/inform7/tests/test_world2inform7.py
@@ -338,7 +338,9 @@ def test_names_disambiguation():
         env.reset()
         game_state, _, done = env.step("take keycard")
         assert "keycard" in game_state.inventory
-        game_state, _, done = env.step("take keycard")
+        game_state, _, done = env.step("take keycard")  # Already in your inventory.
+        assert "rectangular keycard" not in game_state.inventory
+        game_state, _, done = env.step("take rectangular keycard")
         assert "rectangular keycard" in game_state.inventory
 
         game_state, _, done = env.step("unlock gateway with rectangular keycard")


### PR DESCRIPTION
This PR makes several tweaks to the Inform7 generated code.

It now allows customization of the indefinite and definite articles of a game entity (e.g. `some water` rather than `a water`).

Also, one can now specify a set of synonyms that can be used in-game to refer to a given entity (e.g. `read cookbook` or `read recipe` would achieve the same thing).