### PR TITLE
textworld.gym tweaks

### DIFF
--- a/textworld/gym/__init__.py
+++ b/textworld/gym/__init__.py
@@ -1,2 +1,2 @@
 from textworld.gym.utils import make_batch
-from textworld.gym.utils import register_games
+from textworld.gym.utils import register_game, register_games

--- a/textworld/gym/tests/test_textworld_gym.py
+++ b/textworld/gym/tests/test_textworld_gym.py
@@ -15,7 +15,7 @@ def test_register_game():
         env_options = EnvInfos(inventory=True, description=True,
                                admissible_commands=True)
 
-        env_id = textworld.gym.register_games([gamefile], env_options, name="test-single")
+        env_id = textworld.gym.register_game(gamefile, env_options, name="test-single")
         env = gym.make(env_id)
         obs, infos = env.reset()
         assert len(infos) == len(env_options)
@@ -104,7 +104,7 @@ def test_batch_parallel():
 
         env_options = EnvInfos(inventory=True, description=True,
                                admissible_commands=True)
-        env_id = textworld.gym.register_games([gamefile], env_options, name="test-batch-parallel")
+        env_id = textworld.gym.register_game(gamefile, env_options, name="test-batch-parallel")
         env_id = textworld.gym.make_batch(env_id, batch_size, parallel=True)
         env = gym.make(env_id)
 

--- a/textworld/gym/utils.py
+++ b/textworld/gym/utils.py
@@ -68,6 +68,52 @@ def register_games(game_files: List[str],
     return env_id
 
 
+def register_game(game_file: str,
+                  request_infos: Optional[EnvInfos] = None,
+                  max_episode_steps: int = 50,
+                  name: str = "") -> str:
+    """ Make an environment for a particular game.
+
+    Arguments:
+        game_file:
+            Path for the TextWorld game (.ulx).
+        request_infos:
+            For customizing the information returned by this environment
+            (see
+            :py:class:`textworld.EnvInfos <textworld.envs.wrappers.filter.EnvInfos>`
+            for the list of available information).
+        max_episode_steps:
+            Terminate a game after that many steps.
+        name:
+            Name for the new environment, i.e. "tw-{name}-v0". By default,
+            the returned env_id is "tw-v0".
+
+    Returns:
+        The corresponding gym-compatible env_id to use.
+
+    Example:
+
+        >>> from textworld.generator import make_game, compile_game
+        >>> options = textworld.GameOptions()
+        >>> options.seeds = 1234
+        >>> game = make_game(options)
+        >>> game.extras["more"] = "This is extra information."
+        >>> game_file = compile_game(game)
+        <BLANKLINE>
+        >>> import gym
+        >>> import textworld.gym
+        >>> from textworld import EnvInfos
+        >>> request_infos = EnvInfos(description=True, inventory=True, extras=["more"])
+        >>> env_id = textworld.gym.register_game(game_file, request_infos)
+        >>> env = gym.make(env_id)
+        >>> ob, infos = env.reset()
+        >>> print(infos["extra.more"])
+        This is extra information.
+
+    """
+    return register_games([game_file], request_infos, max_episode_steps, name)
+
+
 def make_batch(env_id: str, batch_size: int, parallel: bool = False) -> str:
     """ Make an environment that runs multiple games independently.
 

--- a/textworld/gym/utils.py
+++ b/textworld/gym/utils.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from gym.envs.registration import register, spec
+from gym.envs.registration import register, spec, registry
 
 from textworld import EnvInfos
 
@@ -49,6 +49,12 @@ def register_games(game_files: List[str],
 
     """
     env_id = "tw-{}-v0".format(name) if name else "tw-v0"
+
+    # If env already registered, bump the version number.
+    if env_id in registry.env_specs:
+        base, _ = env_id.rsplit("-v", 1)
+        versions = [int(env_id.rsplit("-v", 1)[-1]) for env_id in registry.env_specs if env_id.startswith(base)]
+        env_id = "{}-v{}".format(base, max(versions) + 1)
 
     register(
         id=env_id,


### PR DESCRIPTION
When registering a game, if the `env_id` already exists, bump its version number. Also, this PR adds `textworld.gym.register_game` for convenience.