### PR TITLE
Remove Tatsu lines in setup.sh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[build-system]
-requires = ["setuptools", "wheel", "tatsu >= 4.3.0"]

--- a/setup.sh
+++ b/setup.sh
@@ -15,10 +15,6 @@ case "${unameOut}" in
     *)          machine="UNKNOWN:${unameOut}"
 esac
 
-# Generate parsers
-tatsu textworld/logic/logic.ebnf -o textworld/logic/parser.py -G textworld/logic/model.py
-tatsu textworld/textgen/textgen.ebnf -o textworld/textgen/parser.py -G textworld/textgen/model.py
-
 cd textworld/thirdparty/
 
 # Install command line Inform 7

--- a/tools/prep-release.sh
+++ b/tools/prep-release.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+set -ex
+echo "Preparing for release...";
+
+# Generate parsers
+tatsu textworld/logic/logic.ebnf -o textworld/logic/parser.py -G textworld/logic/model.py
+tatsu textworld/textgen/textgen.ebnf -o textworld/textgen/parser.py -G textworld/textgen/model.py


### PR DESCRIPTION
Since we already push the files generated by Tatsu, we can remove them from `setup.sh`.

However, with this PR, if someone modifies one of the `*.ebnf`files, they will have to manually call the Tatsu commands accordingly before pushing their changes. To make it more convenient, I've made a small script `tools/prep-release.sh`. It should be called from the root folder of the library.

Closes #116 