### PR TITLE
Add challenge registration mechanism

### DIFF
--- a/scripts/tw-make
+++ b/scripts/tw-make
@@ -16,24 +16,24 @@ import textworld.challenges
 from textworld.generator import NoSuchQuestExistError
 
 
-def _get_available_challenges():
-    challenges = []
-    for challenge in textworld.challenges.CHALLENGES:
-        challenges.append("tw-{}-level{{N}}".format(challenge))
-
-    return challenges
-
-
 def exit_listing_challenges(challenge=None):
     msg = ""
     if challenge is not None:
         msg += "Unknown challenge: {}\n\n".format(args.challenge)
 
     msg += "Available challenges:\n  "
-    msg += "\n  ".join(_get_available_challenges())
-    msg += "\nwhere {N} is an integer."
+    msg += "\n  ".join(sorted(textworld.challenges.CHALLENGES))
     print(msg)
     sys.exit(1)
+
+
+def _maybe_load_third_party_module():
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--third-party")
+    args, _ = parser.parse_known_args()
+    if args.third_party:
+        import importlib.machinery
+        importlib.machinery.SourceFileLoader("tw_custom_challenge", args.third_party).load_module()
 
 
 def parse_args():
@@ -50,7 +50,11 @@ def parse_args():
                                help="Display an overview of the generated game.")
     general_group.add_argument("--save-overview", action="store_true",
                                help="Save the overview image of the generated game alongside the game as a PNG file.")
+    general_group.add_argument("--third-party",
+                               help="Load third-party module. Useful to register new custom challenges on-the-fly.")
     general_group.add_argument("-f", "--force", action="store_true")
+    general_group.add_argument("--list", action="store_true",
+                               help="List available challenges.")
 
     verbosity_group = general_group.add_mutually_exclusive_group()
     verbosity_group.add_argument("--silent", action="store_true")
@@ -118,16 +122,19 @@ def parse_args():
                                     " This setting is ignored if --quest-length is provided."
                                     " Default: %(default)s.")
 
-    challenge_parser = subparsers.add_parser("challenge", parents=[general_parser],
-                                             help='Generate a game for one of the challenges.')
-    challenge_parser.add_argument("challenge",
-                                  help="Name of the builtin challenges, e.g. `tw-coin_collector-level210`")
+    challenge_parsers = []
+    for challenge_name, (desc, _, add_challenge_arguments) in textworld.challenges.CHALLENGES.items():
+        challenge_parser = subparsers.add_parser(challenge_name, parents=[general_parser],
+                                                 help=desc)
+        add_challenge_arguments(challenge_parser)
+        challenge_parsers.append(challenge_parser)
 
-    return parser.parse_args(), (parser, custom_parser, challenge_parser)
+    return parser.parse_args(), (parser, custom_parser, challenge_parsers)
 
 
 if __name__ == "__main__":
-    args, (parser, custom_parser, challenge_parser) = parse_args()
+    args, (parser, custom_parser, challenge_parsers) = parse_args()
+    
     if args.seed is None:
         args.seed = np.random.randint(65635)
 
@@ -146,6 +153,9 @@ if __name__ == "__main__":
     options.grammar.blend_instructions = args.blend_instructions
     options.grammar.blend_descriptions = args.blend_descriptions
     options.grammar.ambiguous_instructions = args.ambiguous_instructions
+
+    if args.list:
+        exit_listing_challenges()
 
     if args.subcommand == "custom":
         options.nb_rooms = args.world_size
@@ -176,23 +186,12 @@ if __name__ == "__main__":
                    " the quest advanced settings (see 'tw-make custom --help').")
             custom_parser.error(msg)
 
-    elif args.subcommand == "challenge":
-        try:
-            # Expected pattern: "tw-challenge-levelN"
-            _, challenge, level = args.challenge.split("-")
-        except ValueError:
-            exit_listing_challenges()
-
-        if challenge not in textworld.challenges.CHALLENGES:
-            exit_listing_challenges(args.challenge)
-
-        level = int(level.lstrip("level"))
-        make_game = textworld.challenges.CHALLENGES[challenge]
-        game = make_game(level, options)
+    elif args.subcommand in textworld.challenges.CHALLENGES:
+        _, make_game, _ = textworld.challenges.CHALLENGES[args.subcommand]
+        game = make_game(settings=args.__dict__, options=options)
         game_file = textworld.generator.compile_game(game, options)
-
     else:
-        parser.error("Subcommand is missing. Specify either 'custom' or 'challange'.")
+        exit_listing_challenges(args.subcommand)
 
     if not args.silent:
         print("Game generated: {}".format(game_file))

--- a/scripts/tw-make
+++ b/scripts/tw-make
@@ -46,8 +46,10 @@ def parse_args():
     general_group.add_argument('--seed', type=int)
     general_group.add_argument('--format', choices=["ulx", "z8"], default="ulx",
                                help="Which format to use when compiling the game. Default: %(default)s")
-    general_group.add_argument("--view", action="store_true",
-                               help="Display the resulting game.")
+    general_group.add_argument("--overview", action="store_true",
+                               help="Display an overview of the generated game.")
+    general_group.add_argument("--save-overview", action="store_true",
+                               help="Save the overview image of the generated game alongside the game as a PNG file.")
     general_group.add_argument("-f", "--force", action="store_true")
 
     verbosity_group = general_group.add_mutually_exclusive_group()
@@ -206,5 +208,13 @@ if __name__ == "__main__":
         print("Nb. locations: {}".format(nb_locations))
         print("Nb. objects: {}".format(nb_objects))
 
-    if args.view:
+    if args.overview:
         textworld.render.visualize(game, interactive=True)
+
+    if args.save_overview:
+        image = textworld.render.visualize(game)
+        overview_file = game_file.replace(".ulx", ".png")
+        image.save(overview_file)
+
+        if not args.silent:
+            print("Overview image: {}".format(overview_file))

--- a/tests/test_tw-make.py
+++ b/tests/test_tw-make.py
@@ -63,12 +63,15 @@ def test_making_a_custom_game():
         textworld.play(output_folder + ".ulx", agent=agent, silent=True)
 
 def test_making_challenge_game():
+    settings = {
+        "tw-treasure_hunter": ["--level", "1"],
+        "tw-coin_collector": ["--level", "1"],
+    }
     with make_temp_directory(prefix="test_tw-challenge") as tmpdir:
         for challenge in textworld.challenges.CHALLENGES:
-            env_id = "tw-{}-level1".format(challenge)
             output_folder = pjoin(tmpdir, "gen_games")
-            game_file = pjoin(output_folder, env_id + ".ulx")
-            command = ["tw-make", "challenge", env_id, "--seed", "1234", "--output", game_file]
+            game_file = pjoin(output_folder, challenge + ".ulx")
+            command = ["tw-make", challenge, "--seed", "1234", "--output", game_file, "--silent"] + settings[challenge]
             assert check_call(command) == 0
 
             assert os.path.isdir(output_folder)

--- a/textworld/challenges/__init__.py
+++ b/textworld/challenges/__init__.py
@@ -1,11 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
-
+from textworld.challenges.registration import register, CHALLENGES
 from textworld.challenges import coin_collector
 from textworld.challenges import treasure_hunter
-
-CHALLENGES = {
-    'coin_collector': coin_collector.make_game_from_level,
-    'treasure_hunter': treasure_hunter.make_game_from_level,
-}

--- a/textworld/challenges/coin_collector.py
+++ b/textworld/challenges/coin_collector.py
@@ -15,24 +15,35 @@ placed at the other end. There is no other objects present in the world
 other than the coin to collect.
 """
 
-import numpy as np
-
+import argparse
 from typing import Mapping, Union, Dict, Optional
 
+import numpy as np
 
 import textworld
 from textworld.generator.graph_networks import reverse_direction
 
 from textworld.utils import encode_seeds
 from textworld.generator.game import GameOptions
+from textworld.challenges import register
 from textworld.challenges.utils import get_seeds_for_game_generation
 
 
-def make_game_from_level(level: int, options: Optional[GameOptions] = None) -> textworld.Game:
-    """ Make a Coin Collector game of the desired difficulty level.
+def build_argparser(parser=None):
+    parser = parser or argparse.ArgumentParser()
+
+    group = parser.add_argument_group('Coin Collector game settings')
+    group.add_argument("--level", required=True, type=int,
+                       help="The difficulty level. Must be between 1 and 300 (included).")
+
+    return parser
+
+
+def make(settings: Mapping[str, str], options: Optional[GameOptions] = None) -> textworld.Game:
+    """ Make a Coin Collector game of the desired difficulty settings.
 
     Arguments:
-        level: Difficulty level (see notes).
+        settings: Difficulty level (see notes). Expected pattern: level[1-300].
         options:
             For customizing the game generation (see
             :py:class:`textworld.GameOptions <textworld.generator.game.GameOptions>`
@@ -51,6 +62,12 @@ def make_game_from_level(level: int, options: Optional[GameOptions] = None) -> t
           distractors rooms *randomly* added along the chain.
         * ...
     """
+    options = options or GameOptions()
+
+    level = settings["level"]
+    if level < 1 or level > 300:
+        raise ValueError("Expected level to be within [1-300].")
+
     n_distractors = (level // 100)
     options.quest_length = level % 100
     options.nb_rooms = (n_distractors + 1) * options.quest_length
@@ -151,3 +168,9 @@ def make_game(mode: str, options: GameOptions) -> textworld.Game:
                        seeds=encode_seeds([options.seeds[k] for k in sorted(options.seeds)]))
     game.metadata["uuid"] = uuid
     return game
+
+
+register(name="tw-coin_collector",
+         desc="Generate a Coin Collector game",
+         make=make,
+         add_arguments=build_argparser)

--- a/textworld/challenges/registration.py
+++ b/textworld/challenges/registration.py
@@ -1,0 +1,37 @@
+# Registry for all challenges in TextWorld.
+CHALLENGES = {}
+
+
+def register(name: str, desc: str,
+             make: callable, add_arguments: callable) -> None:
+    """ Register a new TextWorld challenge.
+
+    Arguments:
+        name:
+            Name of the challenge (must be unique).
+        desc:
+            Bried description of the challenge (for `tw-make --help`).
+        make:
+            Function that makes a game for this challenge. The provided function
+            should expect `(settings: Mapping[str, str], options: GameOptions)`.
+        add_arguments:
+            Function that should add the `argparse` arguments needed for the
+            challenge. The provided function should expect a `argparse.ArgumentParser`
+            object.
+
+    Example:
+
+        >>> from textworld.challenges import register
+        >>> from textworld.challenges import coin_collector
+        >>> def _add_arguments(parser):
+                parser.add_argument("--level", required=True, type=int,
+                                    help="The difficulty level.")
+        >>> \
+        >>> register(name="coin_collector",
+        >>>          make=coin_collector.make,
+        >>>          add_arguments=_add_arguments)
+    """
+    if name in CHALLENGES:
+        raise ValueError("Challenge '{}' already registered.".format(name))
+
+    CHALLENGES[name] = (desc, make, add_arguments)

--- a/textworld/envs/glulx/git_glulx_ml.py
+++ b/textworld/envs/glulx/git_glulx_ml.py
@@ -560,7 +560,6 @@ class GitGlulxMLEnvironment(textworld.Environment):
         #       the output of the following command to check whether debug mode
         #       was used or not (i.e. invalid action not found).
         self._send('tw-trace-actions')  # Turn on debug print for Inform7 action events.
-        self._send('restrict commands')  # Restrict Inform7 commands.
         _extra_output = ""
         for info in self.extra_info:
             _extra_output = self._send('tw-extra-infos {}'.format(info))

--- a/textworld/gym/spaces/text_spaces.py
+++ b/textworld/gym/spaces/text_spaces.py
@@ -3,6 +3,7 @@ import string
 import numpy as np
 
 import gym
+import gym.spaces
 
 
 class VocabularyHasDuplicateTokens(ValueError):


### PR DESCRIPTION
This PR adds a better way of handling TextWorld challenges. It makes it easier to register new challenges not shipped with TextWorld thanks to the `--third-party` option. 

This PR also add the option of showing a visual representation of the game generated with tw-make.py.

This PR also fixes one of the gym.spaces import and remove the "restrict_commands" command automatically sent by `GitGlulxMLEnvironment`.