### PR TITLE
MANIFEST.in: Package all of inform

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,12 +14,9 @@ include textworld/generator/data/logic/*.twl
 include textworld/generator/data/text_grammars/*.twg
 
 recursive-include textworld/render/tmpl *
-recursive-include textworld/thirdparty/glulx *
 recursive-include textworld/thirdparty/frotz *
+recursive-include textworld/thirdparty/glulx *
 recursive-include textworld/thirdparty/inform7 *
-recursive-include textworld/thirdparty/inform7-6M62/bin *
-recursive-include textworld/thirdparty/inform7-6M62/share/inform7/Compilers *
-recursive-include textworld/thirdparty/inform7-6M62/share/inform7/Internal *
-recursive-include textworld/thirdparty/inform7-6M62/share/inform7/Interpreters *
+recursive-include textworld/thirdparty/inform7-6M62 *
 
 prune build


### PR DESCRIPTION
Packaging only some of it causes setup.sh to fail, as the directory
exists but is incomplete.  Ideally we'd only include this in the sdist,
not the wheels, but it seems difficult to separate them.

Fixes #121