### PR TITLE
Improve GameMaker.record_quest

### DIFF
--- a/textworld/generator/maker.py
+++ b/textworld/generator/maker.py
@@ -530,7 +530,8 @@ class GameMaker:
         with make_temp_directory() as tmpdir:
             game_file = self.compile(pjoin(tmpdir, "record_quest.ulx"))
             recorder = Recorder()
-            textworld.play(game_file, wrapper=recorder)
+            agent = textworld.agents.HumanAgent(autocompletion=True)
+            textworld.play(game_file, agent=agent, wrapper=recorder)
 
         # Skip "None" actions.
         actions = [action for action in recorder.actions if action is not None]


### PR DESCRIPTION
Show available actions (Jupyter notebook) / enable autocompletion (terminal) when recording quests with GameMaker.

This is partially addressing #137.

e.g.
```
-= Room A =-
Well I'll be, you are in a place we're calling a Room A.

You smell a fine smell, and follow it to a board. On the board you can make out
an old key, so there's that.

There is a closed door leading east.

There is a note on the floor.

Available actions: ['drop teaspoon', 'examine board', 'examine door', 'examine note', 'examine old key', 'examine teaspoon', 'inventory', 'look', 'put teaspoon on board', 'take note', 'take old key from board']

> take key
You take the old key from the board.

Available actions: ['drop old key', 'drop teaspoon', 'examine board', 'examine door', 'examine note', 'examine old key', 'examine teaspoon', 'inventory', 'look', 'put old key on board', 'put teaspoon on board', 'take note', 'unlock door with old key']

> unlock door with key
You unlock door.
```