### PR TITLE
Support ZMachine games with Gym API

### DIFF
--- a/textworld/gym/tests/test_textworld_gym.py
+++ b/textworld/gym/tests/test_textworld_gym.py
@@ -1,3 +1,5 @@
+import os
+
 import gym
 
 import textworld
@@ -16,6 +18,28 @@ def test_register_game():
                                admissible_commands=True)
 
         env_id = textworld.gym.register_game(gamefile, env_options, name="test-single")
+        env = gym.make(env_id)
+        obs, infos = env.reset()
+        assert len(infos) == len(env_options)
+
+        for cmd in game.main_quest.commands:
+            obs, score, done, infos = env.step(cmd)
+
+        assert done
+        assert score == 1
+
+
+def test_register_zmachine_game():
+    with make_temp_directory() as tmpdir:
+        options = textworld.GameOptions()
+        options.path = tmpdir
+        options.seeds = 1234
+        options.file_ext = ".z8"
+        gamefile, game = textworld.make(options)
+        os.remove(gamefile.replace(".z8", ".json"))  # Simulate an existing Z-Machine game.
+        env_options = EnvInfos()
+
+        env_id = textworld.gym.register_game(gamefile, env_options, name="test-zmachine")
         env = gym.make(env_id)
         obs, infos = env.reset()
         assert len(infos) == len(env_options)

--- a/textworld/gym/utils.py
+++ b/textworld/gym/utils.py
@@ -13,12 +13,14 @@ def register_games(game_files: List[str],
 
     Arguments:
         game_files:
-            Paths for the TextWorld games (.ulx).
+            Paths for the TextWorld games (`*.ulx` + `*.json`, `*.z[1-8]`).
         request_infos:
             For customizing the information returned by this environment
             (see
             :py:class:`textworld.EnvInfos <textworld.envs.wrappers.filter.EnvInfos>`
             for the list of available information).
+
+            .. warning:: This is only supported for `*.ulx` games generated with TextWorld.
         max_episode_steps:
             Terminate a game after that many steps.
         name:
@@ -76,12 +78,14 @@ def register_game(game_file: str,
 
     Arguments:
         game_file:
-            Path for the TextWorld game (.ulx).
+            Path for the TextWorld game (`*.ulx` + `*.json`, `*.z[1-8]`).
         request_infos:
             For customizing the information returned by this environment
             (see
             :py:class:`textworld.EnvInfos <textworld.envs.wrappers.filter.EnvInfos>`
             for the list of available information).
+
+            .. warning:: This is only supported for `*.ulx` games generated with TextWorld.
         max_episode_steps:
             Terminate a game after that many steps.
         name:


### PR DESCRIPTION
This PR allows existing Z-Machine (i.e. not generated by TextWorld) to be registered as Gym's Envs.