### PR TITLE
Fix 163: Coin collector settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ This changelog follows the following convention [https://keepachangelog.com/en/1
 
 - `textworld.envs.wrappers.Filter` expects the environment to wrap as its first argument.
 
+### Fixed
+
+- `tw-make tw-coin_collector` was failing with option `--level {100, 200, or 300}`.
+
 ### Added
 
 - Support requesting list of facts and current location as additional infos.
+- Added `--entity-numbering` option to `tw-make`.
 
 ## [1.1.1] - 2019-02-08
 

--- a/scripts/tw-make
+++ b/scripts/tw-make
@@ -76,6 +76,9 @@ def parse_args():
                            help="Intruction only describes the last action of quest.")
     cfg_group.add_argument("--blend-instructions", action="store_true",
                            help="Blend instructions across consecutive actions.")
+    cfg_group.add_argument("--entity-numbering", action="store_true",
+                           help="Append a number after an entity name if there is not enough"
+                                " variation for it (e.g. 'red apple 2').")
 
     parser = argparse.ArgumentParser(parents=[general_parser])
     subparsers = parser.add_subparsers(dest="subcommand", help='Kind of game to make.')
@@ -155,6 +158,7 @@ if __name__ == "__main__":
     options.grammar.blend_instructions = args.blend_instructions
     options.grammar.blend_descriptions = args.blend_descriptions
     options.grammar.ambiguous_instructions = args.ambiguous_instructions
+    options.grammar.allowed_variables_numbering = args.entity_numbering
 
     if args.list:
         exit_listing_challenges()

--- a/tests/test_tw-make.py
+++ b/tests/test_tw-make.py
@@ -65,7 +65,7 @@ def test_making_a_custom_game():
 def test_making_challenge_game():
     settings = {
         "tw-treasure_hunter": ["--level", "1"],
-        "tw-coin_collector": ["--level", "1"],
+        "tw-coin_collector": ["--level", "1", "--force-entity-numbering"],
         "tw-simple": ["--rewards", "dense", "--goal", "brief"],
     }
     with make_temp_directory(prefix="test_tw-challenge") as tmpdir:

--- a/textworld/challenges/coin_collector.py
+++ b/textworld/challenges/coin_collector.py
@@ -33,6 +33,9 @@ def build_argparser(parser=None):
     group.add_argument("--level", required=True, type=int,
                        help="The difficulty level. Must be between 1 and 300 (included).")
 
+    group.add_argument("--force-entity-numbering", required=True, action="store_true",
+                       help="This will set `--entity-numbering` to be True which is required for this challenge.")
+
     return parser
 
 
@@ -45,6 +48,8 @@ def make(settings: Mapping[str, Any], options: Optional[GameOptions] = None) -> 
             For customizing the game generation (see
             :py:class:`textworld.GameOptions <textworld.generator.game.GameOptions>`
             for the list of available options).
+
+            .. warning:: This challenge requires `options.grammar.allowed_variables_numbering` to be `True`.
 
     Returns:
         Generated game.
@@ -62,6 +67,10 @@ def make(settings: Mapping[str, Any], options: Optional[GameOptions] = None) -> 
         and where the quest length is set according to ((level - 1) % 100 + 1).
     """
     options = options or GameOptions()
+
+    # Needed for games with a lot of rooms.
+    options.grammar.allowed_variables_numbering = settings["force_entity_numbering"]
+    assert options.grammar.allowed_variables_numbering
 
     level = settings["level"]
     if level < 1 or level > 300:
@@ -91,9 +100,14 @@ def make_game(mode: str, options: GameOptions) -> textworld.Game:
             :py:class:`textworld.GameOptions <textworld.generator.game.GameOptions>`
             for the list of available options).
 
+            .. warning:: This challenge requires `options.grammar.allowed_variables_numbering` to be `True`.
+
     Returns:
         Generated game.
     """
+    # Needed for games with a lot of rooms.
+    assert options.grammar.allowed_variables_numbering
+
     if mode == "simple" and float(options.nb_rooms) / options.quest_length > 4:
         msg = ("Total number of rooms must be less than 4 * `quest_length` "
                "when distractor mode is 'simple'.")

--- a/textworld/challenges/coin_collector.py
+++ b/textworld/challenges/coin_collector.py
@@ -16,7 +16,7 @@ other than the coin to collect.
 """
 
 import argparse
-from typing import Mapping, Optional
+from typing import Mapping, Optional, Any
 
 import textworld
 from textworld.generator.graph_networks import reverse_direction
@@ -36,11 +36,11 @@ def build_argparser(parser=None):
     return parser
 
 
-def make(settings: Mapping[str, str], options: Optional[GameOptions] = None) -> textworld.Game:
+def make(settings: Mapping[str, Any], options: Optional[GameOptions] = None) -> textworld.Game:
     """ Make a Coin Collector game of the desired difficulty settings.
 
     Arguments:
-        settings: Difficulty level (see notes). Expected pattern: level[1-300].
+        settings: Difficulty settings (see notes).
         options:
             For customizing the game generation (see
             :py:class:`textworld.GameOptions <textworld.generator.game.GameOptions>`
@@ -52,12 +52,14 @@ def make(settings: Mapping[str, str], options: Optional[GameOptions] = None) -> 
     Notes:
         Difficulty levels are defined as follows:
 
-        * Level   1 to 100: Nb. rooms = level, quest length = level
-        * Level 101 to 200: Nb. rooms = 2 * (level % 100), quest length = level % 100,
+        * Level   1 to 100: Nb. rooms = 1 * quest length.
+        * Level 101 to 200: Nb. rooms = 2 * quest length with
           distractors rooms added along the chain.
-        * Level 201 to 300: Nb. rooms = 3 * (level % 100), quest length = level % 100,
+        * Level 201 to 300: Nb. rooms = 3 * quest length with
           distractors rooms *randomly* added along the chain.
         * ...
+
+        and where the quest length is set according to ((level - 1) % 100 + 1).
     """
     options = options or GameOptions()
 
@@ -65,8 +67,8 @@ def make(settings: Mapping[str, str], options: Optional[GameOptions] = None) -> 
     if level < 1 or level > 300:
         raise ValueError("Expected level to be within [1-300].")
 
-    n_distractors = (level // 100)
-    options.quest_length = level % 100
+    n_distractors = (level - 1) // 100
+    options.quest_length = (level - 1) % 100 + 1
     options.nb_rooms = (n_distractors + 1) * options.quest_length
     distractor_mode = "random" if n_distractors > 2 else "simple"
     return make_game(distractor_mode, options)

--- a/textworld/challenges/tests/test_coin_collector.py
+++ b/textworld/challenges/tests/test_coin_collector.py
@@ -1,42 +1,24 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
-import os
-import glob
-from subprocess import check_call
-from os.path import join as pjoin
-
-from numpy.testing import assert_raises
-
 import textworld
-import textworld.agents
-import textworld.challenges
 from textworld.challenges.coin_collector import make
-from textworld.utils import make_temp_directory
 
 
 def test_making_coin_collector():
-    for level in [1, 100, 101]:
+    expected = {
+        1:   {"quest_length": 1, "nb_rooms": 1},
+        100: {"quest_length": 100, "nb_rooms": 100},
+        101: {"quest_length": 1, "nb_rooms": 2},
+        200: {"quest_length": 100, "nb_rooms": 200},
+        201: {"quest_length": 1, "nb_rooms": 3},
+        300: {"quest_length": 100, "nb_rooms": 300},
+    }
+    for level in [1, 100, 101, 200, 201, 300]:
         options = textworld.GameOptions()
         options.seeds = 1234
 
-        settings = {"level": level}
+        settings = {"level": level, "force_entity_numbering": True}
         game = make(settings, options)
-        assert len(game.quests[0].commands) == (level - 1) % 100 + 1
-
-    # Not enough variation for 200 rooms.
-    options = textworld.GameOptions()
-    options.seeds = 1234
-    settings = {"level": 200}
-    assert_raises(ValueError, make, settings, options)
-
-    for level in [200, 201, 300]:
-        print(level)
-        options = textworld.GameOptions()
-        options.seeds = 1234
-        options.grammar.allowed_variables_numbering = True
-
-        settings = {"level": level}
-        game = make(settings, options)
-        assert len(game.quests[0].commands) == (level - 1) % 100 + 1
-
+        assert len(game.quests[0].commands) == expected[level]["quest_length"]
+        assert len(game.world.rooms) == expected[level]["nb_rooms"]

--- a/textworld/challenges/tests/test_coin_collector.py
+++ b/textworld/challenges/tests/test_coin_collector.py
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+import os
+import glob
+from subprocess import check_call
+from os.path import join as pjoin
+
+from numpy.testing import assert_raises
+
+import textworld
+import textworld.agents
+import textworld.challenges
+from textworld.challenges.coin_collector import make
+from textworld.utils import make_temp_directory
+
+
+def test_making_coin_collector():
+    for level in [1, 100, 101]:
+        options = textworld.GameOptions()
+        options.seeds = 1234
+
+        settings = {"level": level}
+        game = make(settings, options)
+        assert len(game.quests[0].commands) == (level - 1) % 100 + 1
+
+    # Not enough variation for 200 rooms.
+    options = textworld.GameOptions()
+    options.seeds = 1234
+    settings = {"level": 200}
+    assert_raises(ValueError, make, settings, options)
+
+    for level in [200, 201, 300]:
+        print(level)
+        options = textworld.GameOptions()
+        options.seeds = 1234
+        options.grammar.allowed_variables_numbering = True
+
+        settings = {"level": level}
+        game = make(settings, options)
+        assert len(game.quests[0].commands) == (level - 1) % 100 + 1
+

--- a/textworld/generator/inform7/world2inform7.py
+++ b/textworld/generator/inform7/world2inform7.py
@@ -260,6 +260,7 @@ class Inform7Game:
 
     def gen_source(self, seed: int = 1234) -> str:
         source = ""
+        source += "Use MAX_STATIC_DATA of 500000.\n"  # To generate game with 300+ locations.
         source += "When play begins, seed the random-number generator with {}.\n\n".format(seed)
         source += self.define_inform7_kinds()
         # Mention that rooms have a special text attribute called 'internal name'.


### PR DESCRIPTION
Currently, `tw-make tw-coin_collector --level 100` is trying to generate a game with quest length of 0 (which is incorrect). This PR fixes #163.