### PR TITLE
Fix loading saved kb

### DIFF
--- a/textworld/generator/game.py
+++ b/textworld/generator/game.py
@@ -339,8 +339,7 @@ class Game:
     _SERIAL_VERSION = 1
 
     def __init__(self, world: World, grammar: Optional[Grammar] = None,
-                 quests: Iterable[Quest] = (),
-                 kb: Optional[KnowledgeBase] = None) -> None:
+                 quests: Iterable[Quest] = ()) -> None:
         """
         Args:
             world: The world to use for the game.
@@ -352,7 +351,7 @@ class Game:
         self.metadata = {}
         self._objective = None
         self._infos = self._build_infos()
-        self.kb = kb or KnowledgeBase.default()
+        self.kb = world.kb
         self.extras = {}
 
         # Check if we can derive a global winning policy from the quests.
@@ -379,7 +378,7 @@ class Game:
 
     def copy(self) -> "Game":
         """ Make a shallow copy of this game. """
-        game = Game(self.world, self.grammar, self.quests, self.kb)
+        game = Game(self.world, self.grammar, self.quests)
         game._infos = dict(self.infos)
         game._objective = self._objective
         game.metadata = dict(self.metadata)
@@ -435,12 +434,12 @@ class Game:
         if version != cls._SERIAL_VERSION:
             raise ValueError("Cannot deserialize a TextWorld version {} game, expected version {}".format(version, cls._SERIAL_VERSION))
 
-        world = World.deserialize(data["world"])
+        kb = KnowledgeBase.deserialize(data["KB"])
+        world = World.deserialize(data["world"], kb=kb)
         game = cls(world)
         game.grammar = Grammar(data["grammar"])
         game.quests = tuple([Quest.deserialize(d) for d in data["quests"]])
         game._infos = {k: EntityInfo.deserialize(v) for k, v in data["infos"]}
-        game.kb = KnowledgeBase.deserialize(data["KB"])
         game.metadata = data.get("metadata", {})
         game._objective = data.get("objective", None)
         game.extras = data.get("extras", {})

--- a/textworld/gym/utils.py
+++ b/textworld/gym/utils.py
@@ -142,10 +142,8 @@ def make_batch(env_id: str, batch_size: int, parallel: bool = False) -> str:
         id=batch_env_id,
         entry_point=entry_point,
         max_episode_steps=env_spec.max_episode_steps,
-        max_episode_seconds=env_spec.max_episode_seconds,
         nondeterministic=env_spec.nondeterministic,
         reward_threshold=env_spec.reward_threshold,
-        trials=env_spec.trials,
         # Setting the 'vnc' tag avoid wrapping the env with a TimeLimit wrapper. See
         # https://github.com/openai/gym/blob/4c460ba6c8959dd8e0a03b13a1ca817da6d4074f/gym/envs/registration.py#L122
         tags={"vnc": "foo"},


### PR DESCRIPTION
Since `State` now takes a `KnowledgeBase` object as its first argument, when we reload a game we should use the KB that was saved along with it.

EDIT: This PR also avoid using `TimeLimit.max_episode_seconds` which was deprecated recently in OpenAI's Gym (see https://github.com/openai/gym/pull/1402).

EDIT2: This PR also avoid using `trials` which was removed from EnvSpec (see https://github.com/openai/gym/commit/c7bae99a06861004cf17e792e5ef88de00198e8d#diff-3dff15d44236dd4f0f823a6ddb7e8c9b).