### PR TITLE
Do not assume there's an underscore in grammar filenames.

### DIFF
--- a/scripts/tw-make
+++ b/scripts/tw-make
@@ -14,6 +14,7 @@ import textworld
 import textworld.challenges
 
 from textworld.generator import NoSuchQuestExistError
+from textworld.generator.text_grammar import MissingTextGrammar
 
 
 def exit_listing_challenges(challenge=None):
@@ -190,6 +191,11 @@ if __name__ == "__main__":
                    "\n{}\n".format(options) +
                    "\nTry relaxing the quest generation constraints via"
                    " the quest advanced settings (see 'tw-make custom --help').")
+            custom_parser.error(msg)
+        except MissingTextGrammar:
+            msg = ("Theme '--theme {theme}' doesn't exist.\n"
+                   "Check in available themes in '{path}/'."
+                  ).format(theme=args.theme, path=options.kb.text_grammars_path)
             custom_parser.error(msg)
 
     elif args.subcommand in textworld.challenges.CHALLENGES:

--- a/textworld/generator/tests/test_text_grammar.py
+++ b/textworld/generator/tests/test_text_grammar.py
@@ -20,6 +20,7 @@ class TestGrammarOptions(unittest.TestCase):
         options2 = GrammarOptions.deserialize(data)
         assert options == options2
 
+
 class GrammarTest(unittest.TestCase):
     def test_grammar_eq(self):
         grammar = Grammar()
@@ -27,8 +28,8 @@ class GrammarTest(unittest.TestCase):
         self.assertEqual(grammar, grammar2, "Testing two grammar files are equivalent")
 
     def test_grammar_eq2(self):
-        grammar = Grammar()
-        grammar2 = Grammar(options={'theme': 'something'})
+        grammar = Grammar(options={'theme': 'house'})
+        grammar2 = Grammar(options={'theme': 'basic'})
         self.assertNotEqual(grammar, grammar2, "Testing two different grammar files are not equal")
 
     def test_grammar_get_random_expansion_fail(self):

--- a/textworld/generator/text_grammar.py
+++ b/textworld/generator/text_grammar.py
@@ -151,7 +151,7 @@ class Grammar:
         self.theme = self.options.theme
 
         # Load the object names file
-        files = glob.glob(pjoin(KnowledgeBase.default().text_grammars_path, glob.escape(self.theme) + "_*.twg"))
+        files = glob.glob(pjoin(KnowledgeBase.default().text_grammars_path, glob.escape(self.theme) + "*.twg"))
         for filename in files:
             self._parse(filename)
 

--- a/textworld/generator/text_grammar.py
+++ b/textworld/generator/text_grammar.py
@@ -20,7 +20,6 @@ from textworld.textgen import TextGrammar
 
 NB_EXPANSION_RETRIES = 20
 
-
 def fix_determinant(var):
     var = var.replace("  ", " ")
     var = var.replace(" a a", " an a")
@@ -34,6 +33,12 @@ def fix_determinant(var):
     var = var.replace(" A o", " An o")
     var = var.replace(" A u", " An u")
     return var
+
+
+class MissingTextGrammar(NameError):
+    def __init__(self, path):
+        msg = "Cannot find any theme files: {path}."
+        super().__init__(msg.format(path=path))
 
 
 class GrammarOptions:
@@ -151,7 +156,11 @@ class Grammar:
         self.theme = self.options.theme
 
         # Load the object names file
-        files = glob.glob(pjoin(KnowledgeBase.default().text_grammars_path, glob.escape(self.theme) + "*.twg"))
+        path = pjoin(KnowledgeBase.default().text_grammars_path, glob.escape(self.theme) + "*.twg")
+        files = glob.glob(path)
+        if len(files) == 0:
+            raise MissingTextGrammar(path)
+
         for filename in files:
             self._parse(filename)
 


### PR DESCRIPTION
This PR makes the format of the grammar files (*.twg) more flexible in the sense that they need to match `{theme}*.twg` instead of `{theme}_*.twg` (note the removed underscore).