### PR TITLE
Sort list of paths returned by glob

### DIFF
--- a/textworld/generator/data/__init__.py
+++ b/textworld/generator/data/__init__.py
@@ -119,6 +119,7 @@ class KnowledgeBase:
 
         # Load knowledge base related files.
         paths = glob.glob(pjoin(target_dir, "logic", "*"))
+        paths = sorted(paths)  # Cannot rely on glob ordering.
         logic = GameLogic.load(paths)
 
         # Load text generation related files.

--- a/textworld/generator/text_grammar.py
+++ b/textworld/generator/text_grammar.py
@@ -157,7 +157,7 @@ class Grammar:
 
         # Load the object names file
         path = pjoin(KnowledgeBase.default().text_grammars_path, glob.escape(self.theme) + "*.twg")
-        files = glob.glob(path)
+        files = sorted(glob.glob(path))  # Cannot rely on glob ordering.
         if len(files) == 0:
             raise MissingTextGrammar(path)
 


### PR DESCRIPTION
A sneaky bug was happening when generating games on different machines.

Indirectly, the ordering of the dictionary `Type.children` was depending on the ordering of the `*.twl` files as returned by the OS (via `glob.glob`). As a result, the order of the child types was machine-dependent (see https://github.com/microsoft/TextWorld/blob/master/textworld/logic/__init__.py#L263)