### PR TITLE
FIX: quests tracking was failing with unneeded irreversible actions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog follows the following convention [https://keepachangelog.com/en/1
 ### Fixed
 
 - `tw-make tw-coin_collector` was failing with option `--level {100, 200, or 300}`.
+- Quest tracking was failing when an irreversible, but unneeded, action was performed.
 
 ### Added
 


### PR DESCRIPTION
This PR makes sure quest tracking is not stopping prematurely when an irreversible - but unneeded - action is performed in a game. E.g. eat a cookie when the quest is all about cooking a carrot!