### PR TITLE
Quest's __eq__ was not comparing commands.

### DIFF
--- a/textworld/envs/wrappers/tests/test_tw_inform7.py
+++ b/textworld/envs/wrappers/tests/test_tw_inform7.py
@@ -268,19 +268,19 @@ class TestStateTracking(unittest.TestCase):
         for env in [self.env_ulx, self.env_z8]:
             initial_state = env.reset()
 
-            assert initial_state.policy_commands == self.game.main_quest.commands
+            assert tuple(initial_state.policy_commands) == self.game.main_quest.commands
 
             game_state, _, _ = env.step("drop carrot")
-            expected = ["take carrot"] + self.game.main_quest.commands
-            assert game_state.policy_commands == expected, game_state.policy_commands
+            expected = ("take carrot",) + self.game.main_quest.commands
+            assert tuple(game_state.policy_commands) == expected, game_state.policy_commands
 
             game_state, _, _ = env.step("take carrot")
             expected = self.game.main_quest.commands
-            assert game_state.policy_commands == expected
+            assert tuple(game_state.policy_commands) == expected
 
             game_state, _, _ = env.step("go east")
             expected = self.game.main_quest.commands[1:]
-            assert game_state.policy_commands == expected
+            assert tuple(game_state.policy_commands) == expected
 
             game_state, _, _ = env.step("insert carrot into chest")
             game_state, _, _ = env.step("close chest")
@@ -288,7 +288,7 @@ class TestStateTracking(unittest.TestCase):
 
             # Test parallel subquests.
             game_state = env.reset()
-            commands = self.game.main_quest.commands
+            commands = list(self.game.main_quest.commands)
             assert game_state.policy_commands == commands
             game_state, _, _ = env.step("close wooden door")
             assert game_state.policy_commands == ["open wooden door"] + commands
@@ -302,7 +302,7 @@ class TestStateTracking(unittest.TestCase):
 
             # Irreversible action.
             game_state = env.reset()
-            assert game_state.policy_commands == self.game.main_quest.commands
+            assert tuple(game_state.policy_commands) == self.game.main_quest.commands
             game_state, _, done = env.step("eat carrot")
             assert done
             assert game_state.lost

--- a/textworld/generator/game.py
+++ b/textworld/generator/game.py
@@ -87,9 +87,25 @@ class Event:
                         to get triggered.
             commands: Human readable version of the actions.
         """
-        self.actions = tuple(actions)
-        self.commands = tuple(commands)
+        self.actions = actions
+        self.commands = commands
         self.condition = self.set_conditions(conditions)
+
+    @property
+    def actions(self) -> Iterable[Action]:
+        return self._actions
+
+    @actions.setter
+    def actions(self, actions: Iterable[Action]) -> None:
+        self._actions = tuple(actions)
+
+    @property
+    def commands(self) -> Iterable[str]:
+        return self._commands
+
+    @commands.setter
+    def commands(self, commands: Iterable[str]) -> None:
+        self._commands = tuple(commands)
 
     def is_triggering(self, state: State) -> bool:
         """ Check if this event would be triggered in a given state. """
@@ -121,15 +137,13 @@ class Event:
         return self.condition
 
     def __hash__(self) -> int:
-        return hash((tuple(self.actions),
-                     tuple(self.commands),
-                     self.condition))
+        return hash((self.actions, self.commands, self.condition))
 
     def __eq__(self, other: Any) -> bool:
-        return (isinstance(other, Event) and
-                self.actions == other.actions and
-                self.commands == other.commands and
-                self.condition == other.condition)
+        return (isinstance(other, Event)
+                and self.actions == other.actions
+                and self.commands == other.commands
+                and self.condition == other.condition)
 
     @classmethod
     def deserialize(cls, data: Mapping) -> "Event":
@@ -211,6 +225,30 @@ class Quest:
         if len(self.win_events) == 0 and len(self.fail_events) == 0:
             raise UnderspecifiedQuestError()
 
+    @property
+    def win_events(self) -> Iterable[Event]:
+        return self._win_events
+
+    @win_events.setter
+    def win_events(self, events: Iterable[Event]) -> None:
+        self._win_events = tuple(events)
+
+    @property
+    def fail_events(self) -> Iterable[Event]:
+        return self._fail_events
+
+    @fail_events.setter
+    def fail_events(self, events: Iterable[Event]) -> None:
+        self._fail_events = tuple(events)
+
+    @property
+    def commands(self) -> Iterable[str]:
+        return self._commands
+
+    @commands.setter
+    def commands(self, commands: Iterable[str]) -> None:
+        self._commands = tuple(commands)
+
     def is_winning(self, state: State) -> bool:
         """ Check if this quest is winning in that particular state. """
         return any(event.is_triggering(state) for event in self.win_events)
@@ -220,19 +258,16 @@ class Quest:
         return any(event.is_triggering(state) for event in self.fail_events)
 
     def __hash__(self) -> int:
-        return hash((tuple(self.win_events),
-                     tuple(self.fail_events),
-                     self.reward,
-                     self.desc,
-                     tuple(self.commands)))
+        return hash((self.win_events, self.fail_events, self.reward,
+                     self.desc, self.commands))
 
     def __eq__(self, other: Any) -> bool:
-        return (isinstance(other, Quest) and
-                self.win_events == other.win_events and
-                self.fail_events == other.fail_events and
-                self.reward == other.reward and
-                self.desc == other.desc,
-                self.commands == other.commands)
+        return (isinstance(other, Quest)
+                and self.win_events == other.win_events
+                and self.fail_events == other.fail_events
+                and self.reward == other.reward
+                and self.desc == other.desc
+                and self.commands == other.commands)
 
     @classmethod
     def deserialize(cls, data: Mapping) -> "Quest":
@@ -378,9 +413,10 @@ class Game:
 
     def copy(self) -> "Game":
         """ Make a shallow copy of this game. """
-        game = Game(self.world, self.grammar, self.quests)
+        game = Game(self.world, None, self.quests)
         game._infos = dict(self.infos)
         game._objective = self._objective
+        game.main_quest = self.main_quest
         game.metadata = dict(self.metadata)
         game.extras = dict(self.extras)
         return game

--- a/textworld/generator/tests/test_game.py
+++ b/textworld/generator/tests/test_game.py
@@ -90,7 +90,7 @@ def test_reloading_game_with_custom_kb():
 
     commands = ["drop customized object"]
     quest = M.set_quest_from_commands(commands)
-    assert quest.commands == commands
+    assert quest.commands == tuple(commands)
     game = M.build()
     assert game == Game.deserialize(game.serialize())
 


### PR DESCRIPTION
This PR fixes an issue with `Quest` objects comparison where the internal text commands were not properly compared.

This PR also makes sure that some of the `Event` and `Quest` attributes are tuples as expected.

This PR also changes the behavior of `Game.copy`. Now, copied `Game.grammar` objects will have their attribute `.grammar` set to `None` to avoid changing the entity names.