### PR TITLE
Disable HomeBrew auto-update in Travis setup script.

### DIFF
--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -3,6 +3,9 @@
 set -e
 
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+    # Disable Homebrew's auto-update
+    # See https://discuss.circleci.com/t/brew-link-step-failing-on-python-dependency/33925/8
+    brew unlink python@2
     brew update
     brew tap homebrew/cask
     brew cask install google-chrome chromedriver


### PR DESCRIPTION
It seems Homebrew is complaining about [Python 2 reaching EOL](https://discourse.brew.sh/t/python-2-eol-2020/4647/25).

~This PR disables Homebrew's auto-update feature according to
https://discuss.circleci.com/t/brew-link-step-failing-on-python-dependency/33925/8.~
This PR unlink python2 from Howebrew as done in https://github.com/bitcoin/bitcoin/pull/17849.