### PR TITLE
FIX: wrong memoization key

### DIFF
--- a/textworld/gym/utils.py
+++ b/textworld/gym/utils.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from gym.envs.registration import register, spec, registry
+from gym.envs.registration import register, registry
 
 from textworld import EnvInfos
 
@@ -133,7 +133,6 @@ def make_batch(env_id: str, batch_size: int, parallel: bool = False) -> str:
         The corresponding gym-compatible env_id to use.
     """
     batch_env_id = "batch{}-".format(batch_size) + env_id
-    env_spec = spec(env_id)
     entry_point = 'textworld.gym.envs:BatchEnv'
     if parallel and batch_size > 1:
         entry_point = 'textworld.gym.envs:ParallelBatchEnv'
@@ -141,12 +140,6 @@ def make_batch(env_id: str, batch_size: int, parallel: bool = False) -> str:
     register(
         id=batch_env_id,
         entry_point=entry_point,
-        max_episode_steps=env_spec.max_episode_steps,
-        nondeterministic=env_spec.nondeterministic,
-        reward_threshold=env_spec.reward_threshold,
-        # Setting the 'vnc' tag avoid wrapping the env with a TimeLimit wrapper. See
-        # https://github.com/openai/gym/blob/4c460ba6c8959dd8e0a03b13a1ca817da6d4074f/gym/envs/registration.py#L122
-        tags={"vnc": "foo"},
         kwargs={'env_id': env_id, 'batch_size': batch_size}
     )
 

--- a/textworld/logic/__init__.py
+++ b/textworld/logic/__init__.py
@@ -531,8 +531,14 @@ class Variable:
         return cls(data["name"], data["type"])
 
 
-SignatureTracker = memento_factory('SignatureTracker',
-                                   lambda cls, args, kwargs: (cls, args[0] + '//'.join(args[1])))
+SignatureTracker = memento_factory(
+    'SignatureTracker',
+    lambda cls, args, kwargs: (
+        cls,
+        kwargs.get("name", args[0] if len(args) >= 1 else None),
+        tuple(kwargs.get("types", args[1] if len(args) == 2 else []))
+    )
+)
 
 
 @total_ordering
@@ -593,10 +599,14 @@ class Signature(with_metaclass(SignatureTracker, object)):
         return _parse_and_convert(expr, rule_name="onlySignature")
 
 
-PropositionTracker = memento_factory('PropositionTracker',
-                                     lambda cls, args, kwargs: (
-                                         cls,
-                                         args[0] + '//'.join(v.name for v in args[1]) if len(args) == 2 else ""))
+PropositionTracker = memento_factory(
+    'PropositionTracker',
+    lambda cls, args, kwargs: (
+        cls,
+        kwargs.get("name", args[0] if len(args) >= 1 else None),
+        tuple(v.name for v in kwargs.get("arguments", args[1] if len(args) == 2 else []))
+    )
+)
 
 
 @total_ordering

--- a/textworld/logic/tests/test_logic.py
+++ b/textworld/logic/tests/test_logic.py
@@ -227,3 +227,44 @@ def test_match_complex():
                           "          -> in(o4: o, I) & free(slot2: slot) & free(slot3: slot)")
     for _ in range(1000):
         assert rule.match(action) == mapping
+
+
+def test_mementos_memoization():
+    # Variable-free proposition.
+    fact = Proposition("name")
+    assert Proposition("name") is fact
+    assert Proposition(name="name") is fact
+    assert Proposition("name", []) is fact
+    assert Proposition("name", arguments=[]) is fact
+    assert Proposition(name="name", arguments=[]) is fact
+    assert Proposition("name2") is not fact
+
+    # General proposition.
+    variables = [Variable("var_1"), Variable("var_2")]
+    fact2 = Proposition("name", variables)
+    assert fact2 is not fact
+    assert Proposition("name", variables) is fact2
+    assert Proposition("name", arguments=variables) is fact2
+    assert Proposition(name="name", arguments=variables) is fact2
+    assert Proposition("name2", variables) is not fact2
+
+    assert Proposition("name", variables[:1]) is not fact2  # Missing a variable.
+    assert Proposition("name", variables[::-1]) is not fact2  # Variable are reversed.
+
+    # Type-free signature.
+    sig = Signature("name")
+    assert Signature("name") is sig
+    assert Signature("name", []) is sig
+    assert Signature("name", types=[]) is sig
+    assert Signature(name="name", types=[]) is sig
+
+    # General signature.
+    types = ["type_A", "type_B"]
+    sig2 = Signature("name", types)
+    assert sig2 is not sig
+    assert Signature("name", types) is sig2
+    assert Signature("name", types=types) is sig2
+    assert Signature(name="name", types=types) is sig2
+
+    assert Signature("name", types[:1]) is not sig2  # Missing a variable.
+    assert Signature("name", types[::-1]) is not sig2  # Variable are reversed.


### PR DESCRIPTION
The key used for memoizing the `Proposition` and `Signature` instances was ignoring `kwargs`.