### PR TITLE
Refactor challenges to include knowledge base data.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,8 @@ include textworld/logic/*.ebnf
 include textworld/textgen/*.ebnf
 include textworld/generator/data/logic/*.twl
 include textworld/generator/data/text_grammars/*.twg
+include textworld/challenges/*/textworld_data/logic/*.twl
+include textworld/challenges/*/textworld_data/text_grammars/*.twg
 
 recursive-include textworld/render/tmpl *
 

--- a/scripts/tw-make
+++ b/scripts/tw-make
@@ -67,7 +67,17 @@ def parse_args():
     verbosity_group.add_argument("--silent", action="store_true")
     verbosity_group.add_argument("-v", "--verbose", action="store_true")
 
-    cfg_group = general_parser.add_argument_group('Grammar settings')
+    parser = argparse.ArgumentParser(parents=[general_parser])
+    subparsers = parser.add_subparsers(dest="subcommand", help='Kind of game to make.')
+
+    custom_parser = subparsers.add_parser("custom", parents=[general_parser],
+                                          help='Make a custom game.')
+    custom_parser.add_argument("--world-size", type=int, default=5, metavar="SIZE",
+                               help="Nb. of rooms in the world.")
+    custom_parser.add_argument("--nb-objects", type=int, default=10, metavar="NB",
+                               help="Minimum nb. of objects in the world.")
+
+    cfg_group = custom_parser.add_argument_group('Grammar settings')
     cfg_group.add_argument("--theme", default="house",
                            help="Theme to use for generating the text. Default: %(default)s")
     cfg_group.add_argument("--include-adj", action="store_true",
@@ -83,16 +93,6 @@ def parse_args():
     cfg_group.add_argument("--entity-numbering", action="store_true",
                            help="Append a number after an entity name if there is not enough"
                                 " variation for it (e.g. 'red apple 2').")
-
-    parser = argparse.ArgumentParser(parents=[general_parser])
-    subparsers = parser.add_subparsers(dest="subcommand", help='Kind of game to make.')
-
-    custom_parser = subparsers.add_parser("custom", parents=[general_parser],
-                                          help='Make a custom game.')
-    custom_parser.add_argument("--world-size", type=int, default=5, metavar="SIZE",
-                               help="Nb. of rooms in the world.")
-    custom_parser.add_argument("--nb-objects", type=int, default=10, metavar="NB",
-                               help="Minimum nb. of objects in the world.")
 
     quest_group = custom_parser.add_argument_group('Quest settings')
     quest_group.add_argument("--nb-parallel-quests", type=int, default=1,
@@ -156,13 +156,6 @@ if __name__ == "__main__":
     options.path = pjoin(os.path.abspath(dirname), basename)
     options.file_ext = "." + args.format
     options.force_recompile = args.force
-    options.grammar.theme = args.theme
-    options.grammar.include_adj = args.include_adj
-    options.grammar.only_last_action = args.only_last_action
-    options.grammar.blend_instructions = args.blend_instructions
-    options.grammar.blend_descriptions = args.blend_descriptions
-    options.grammar.ambiguous_instructions = args.ambiguous_instructions
-    options.grammar.allowed_variables_numbering = args.entity_numbering
 
     if args.list:
         exit_listing_challenges()
@@ -177,6 +170,14 @@ if __name__ == "__main__":
         options.chaining.max_breadth = args.quest_max_breadth
         options.chaining.max_depth = args.quest_max_depth
         options.chaining.max_length = args.quest_max_length
+
+        options.grammar.theme = args.theme
+        options.grammar.include_adj = args.include_adj
+        options.grammar.only_last_action = args.only_last_action
+        options.grammar.blend_instructions = args.blend_instructions
+        options.grammar.blend_descriptions = args.blend_descriptions
+        options.grammar.ambiguous_instructions = args.ambiguous_instructions
+        options.grammar.allowed_variables_numbering = args.entity_numbering
 
         if args.quest_length:
             options.chaining.min_length = args.quest_length

--- a/tests/test_tw-make.py
+++ b/tests/test_tw-make.py
@@ -67,7 +67,7 @@ def test_making_a_custom_game():
 def test_making_challenge_game():
     settings = {
         "tw-treasure_hunter": ["--level", "5"],
-        "tw-coin_collector": ["--level", "5", "--force-entity-numbering"],
+        "tw-coin_collector": ["--level", "5"],
         "tw-simple": ["--rewards", "dense", "--goal", "brief"],
     }
     with make_temp_directory(prefix="test_tw-challenge") as tmpdir:

--- a/textworld/challenges/__init__.py
+++ b/textworld/challenges/__init__.py
@@ -2,6 +2,6 @@
 # Licensed under the MIT license.
 
 from textworld.challenges.registration import register, CHALLENGES
-from textworld.challenges import coin_collector
-from textworld.challenges import treasure_hunter
-from textworld.challenges import simple
+from textworld.challenges.tw_coin_collector import coin_collector
+from textworld.challenges.tw_treasure_hunter import treasure_hunter
+from textworld.challenges.tw_simple import simple

--- a/textworld/challenges/tests/test_coin_collector.py
+++ b/textworld/challenges/tests/test_coin_collector.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import textworld
-from textworld.challenges.coin_collector import make
+from textworld.challenges import coin_collector
 
 
 def test_making_coin_collector():
@@ -18,7 +18,7 @@ def test_making_coin_collector():
         options = textworld.GameOptions()
         options.seeds = 1234
 
-        settings = {"level": level, "force_entity_numbering": True}
-        game = make(settings, options)
+        settings = {"level": level}
+        game = coin_collector.make(settings, options)
         assert len(game.quests[0].commands) == expected[level]["quest_length"]
         assert len(game.world.rooms) == expected[level]["nb_rooms"]

--- a/textworld/challenges/tw_coin_collector/coin_collector.py
+++ b/textworld/challenges/tw_coin_collector/coin_collector.py
@@ -15,15 +15,21 @@ placed at the other end. There is no other objects present in the world
 other than the coin to collect.
 """
 
+import os
 import argparse
+from os.path import join as pjoin
 from typing import Mapping, Optional, Any
 
 import textworld
 from textworld.generator.graph_networks import reverse_direction
 
 from textworld.utils import encode_seeds
+from textworld.generator.data import KnowledgeBase
 from textworld.generator.game import GameOptions, Quest, Event
 from textworld.challenges import register
+
+
+KB_PATH = pjoin(os.path.dirname(__file__), "textworld_data")
 
 
 def build_argparser(parser=None):
@@ -32,9 +38,6 @@ def build_argparser(parser=None):
     group = parser.add_argument_group('Coin Collector game settings')
     group.add_argument("--level", required=True, type=int,
                        help="The difficulty level. Must be between 1 and 300 (included).")
-
-    group.add_argument("--force-entity-numbering", required=True, action="store_true",
-                       help="This will set `--entity-numbering` to be True which is required for this challenge.")
 
     return parser
 
@@ -49,7 +52,7 @@ def make(settings: Mapping[str, Any], options: Optional[GameOptions] = None) -> 
             :py:class:`textworld.GameOptions <textworld.generator.game.GameOptions>`
             for the list of available options).
 
-            .. warning:: This challenge requires `options.grammar.allowed_variables_numbering` to be `True`.
+            .. warning:: This challenge enforces `options.grammar.allowed_variables_numbering` to be `True`.
 
     Returns:
         Generated game.
@@ -68,9 +71,11 @@ def make(settings: Mapping[str, Any], options: Optional[GameOptions] = None) -> 
     """
     options = options or GameOptions()
 
+    # Load knowledge base specific to this challenge.
+    options.kb = KnowledgeBase.load(KB_PATH)
+
     # Needed for games with a lot of rooms.
-    options.grammar.allowed_variables_numbering = settings["force_entity_numbering"]
-    assert options.grammar.allowed_variables_numbering
+    options.grammar.allowed_variables_numbering = True
 
     level = settings["level"]
     if level < 1 or level > 300:

--- a/textworld/challenges/tw_coin_collector/textworld_data/logic/inventory.twl
+++ b/textworld/challenges/tw_coin_collector/textworld_data/logic/inventory.twl
@@ -1,0 +1,32 @@
+# Inventory
+type I {
+    predicates {
+        in(o, I);
+    }
+
+    rules {
+        take :: $at(P, r) & at(o, r) -> in(o, I);
+        drop :: $at(P, r) & in(o, I) -> at(o, r);
+        inventory :: at(P, r) -> at(P, r);  # Nothing changes.
+        examine/I :: in(o, I) -> in(o, I);  # Nothing changes.
+    }
+
+    reverse_rules {
+        inventory :: inventory;
+        take :: drop;
+        examine/I :: examine/I;
+    }
+
+    inform7 {
+        predicates {
+            in(o, I) :: "The player carries the {o}";
+        }
+
+        commands {
+            take :: "take {o}" :: "taking the {o}";
+            drop :: "drop {o}" :: "dropping the {o}";
+            inventory :: "inventory" :: "taking inventory";
+            examine/I :: "examine {o}" :: "examining the {o}";
+        }
+    }
+}

--- a/textworld/challenges/tw_coin_collector/textworld_data/logic/object.twl
+++ b/textworld/challenges/tw_coin_collector/textworld_data/logic/object.twl
@@ -1,0 +1,14 @@
+# object
+type o : t {
+    constraints {
+        obj1 :: in(o, I) & at(o, r) -> fail();
+        obj2 :: at(o, r) & at(o, r') -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "object-like";
+            definition :: "object-like is portable.";
+        }
+    }
+}

--- a/textworld/challenges/tw_coin_collector/textworld_data/logic/player.twl
+++ b/textworld/challenges/tw_coin_collector/textworld_data/logic/player.twl
@@ -1,0 +1,16 @@
+# Player
+type P {
+    rules {
+        look :: at(P, r) -> at(P, r);  # Nothing changes.
+    }
+
+    reverse_rules {
+        look :: look;
+    }
+
+    inform7 {
+        commands {
+            look :: "look" :: "looking";
+        }
+    }
+}

--- a/textworld/challenges/tw_coin_collector/textworld_data/logic/room.twl
+++ b/textworld/challenges/tw_coin_collector/textworld_data/logic/room.twl
@@ -1,0 +1,69 @@
+# room
+type r {
+    predicates {
+        at(P, r);
+        at(t, r);
+
+        north_of(r, r);
+        west_of(r, r);
+
+        free(r, r);
+
+        south_of(r, r') = north_of(r', r);
+        east_of(r, r') = west_of(r', r);
+    }
+
+    rules {
+        go/north :: at(P, r) & $north_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/south :: at(P, r) & $south_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/east  :: at(P, r) & $east_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/west  :: at(P, r) & $west_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+    }
+
+    reverse_rules {
+        go/north :: go/south;
+        go/west :: go/east;
+    }
+
+    constraints {
+        r1 :: at(P, r) & at(P, r') -> fail();
+
+        # An exit direction can only lead to one room.
+        nav_rr1 :: north_of(r, r') & north_of(r'', r') -> fail();
+        nav_rr2 :: south_of(r, r') & south_of(r'', r') -> fail();
+        nav_rr3 :: east_of(r, r') & east_of(r'', r') -> fail();
+        nav_rr4 :: west_of(r, r') & west_of(r'', r') -> fail();
+
+        # Two rooms can only be connected once with each other.
+        nav_rrA :: north_of(r, r') & south_of(r, r') -> fail();
+        nav_rrB :: north_of(r, r') & west_of(r, r') -> fail();
+        nav_rrC :: north_of(r, r') & east_of(r, r') -> fail();
+        nav_rrD :: south_of(r, r') & west_of(r, r') -> fail();
+        nav_rrE :: south_of(r, r') & east_of(r, r') -> fail();
+        nav_rrF :: west_of(r, r')  & east_of(r, r') -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "room";
+        }
+
+        predicates {
+            at(P, r) :: "The player is in {r}";
+            at(t, r) :: "The {t} is in {r}";
+            free(r, r') :: "";  # No equivalent in Inform7.
+
+            north_of(r, r') :: "The {r} is mapped north of {r'}";
+            south_of(r, r') :: "The {r} is mapped south of {r'}";
+            east_of(r, r') :: "The {r} is mapped east of {r'}";
+            west_of(r, r') :: "The {r} is mapped west of {r'}";
+        }
+
+        commands {
+            go/north :: "go north" :: "going north";
+            go/south :: "go south" :: "going south";
+            go/east :: "go east" :: "going east";
+            go/west :: "go west" :: "going west";
+        }
+    }
+}

--- a/textworld/challenges/tw_coin_collector/textworld_data/logic/thing.twl
+++ b/textworld/challenges/tw_coin_collector/textworld_data/logic/thing.twl
@@ -1,0 +1,20 @@
+# thing
+type t {
+    rules {
+        examine/t :: at(P, r) & $at(t, r) -> at(P, r);
+    }
+
+    reverse_rules {
+        examine/t :: examine/t;
+    }
+
+    inform7 {
+        type {
+            kind :: "thing";
+        }
+
+        commands {
+            examine/t :: "examine {t}" :: "examining the {t}";
+        }
+    }
+}

--- a/textworld/challenges/tw_coin_collector/textworld_data/text_grammars/house_instruction.twg
+++ b/textworld/challenges/tw_coin_collector/textworld_data/text_grammars/house_instruction.twg
@@ -1,0 +1,154 @@
+#-------------------------
+#Instructions Grammar
+#-------------------------
+obj_types:(o|k|f)
+obj_types_no_key:(o|f)
+on_types:(c|s)
+lock_types:(c|d)
+eat_types:(f)
+close_open_types:(d|c)
+lock_type_var:#lock_types#;#lock_types# #in_the_(r)#
+(s)_var:(s);(s) #in_the_(r)#
+(c)_var:(c);(c) #in_the_(r)#
+on_var:#on_types#;#on_types# #in_the_(r)#
+in_the_(r):in the (r);within the (r);inside the (r)
+make_syn_u:Make sure;Assure;Make it so;Doublecheck;Look and see;Make absolutely sure
+make_syn_v:make sure;assure;make it so;doublecheck;look and see;make absolutely sure
+by_the_syn:with the
+init_syn:in it;inside;placed inside
+into_syn:into;inside
+#actions
+##actions should start with a verb (ie:ensure, make sure, etc (these could probably just be a tag))
+look:look around in (r).
+examine:examine (o|k|f|d|c|s|t).
+inventory:examine your inventory.
+take:#take_synonym_1# the #obj_types# in the (r).;#take_synonym_1# the #obj_types# from the (r).;#take_synonym_1# the #obj_types# that's in the (r).
+take_synonym_1:take;retrieve;recover;pick up
+take/s:#take_synonym_1# the #obj_types# from the #on_var#.
+take/c:#take_synonym_1# the #obj_types# from the #on_var#.
+take:#pick-up_synonym_1# the #obj_types# from the floor of the (r).
+pick-up_synonym_1:pick-up;retrieve;recover;pick up;lift
+pick-up_synonym_v:Pick-up;Retrieve;Recover;Pick up;Lift
+insert:#insert_syn_1# the #obj_types# #into_syn# the #(c)_var#.;you can #insert_syn_1# the #obj_types# #into_syn# the #(c)_var#.
+insert_syn_u:Insert;Put;Place;Deposit
+insert_syn_1:insert;put;place;deposit
+insert_syn_v:inserted;put;placed;deposited
+begood:good;great;fantastic;a great idea
+put:#put_syn_v# the #obj_types# on the #(s)_var#.
+put_syn_u:Put;Place;Sit;Rest
+put_syn_v:put;place;sit;rest
+on_it_syn:on it;upon it
+drop:#drop_syn_v# the #obj_types# on the floor of the (r).
+drop_syn_u:Place
+drop_syn_v:place;drop;ditch;throw;toss;deposit
+eat:#eat_syn_1# the #eat_var#.
+eat_syn_u:Eat;
+eat_syn_1:eat;
+eat_syn_v:eaten;
+open:open the #lock_type_var#.;ensure that the #lock_type_var# is open.;#make_syn_v# that the #lock_type_var# is #open_syn#.
+open_syn:opened;open;wide open;ajar
+close:close the #lock_type_var#.;#make_syn_v# that the #lock_type_var# is #closed_syn#.
+closed_syn:closed;shut
+eat_var:#eat_types#;#eat_types#
+on_var:#on_types#;#on_types# #in_the_(r)#
+unlock:#unlock_key#;#unlock_no_key#
+unlock_key:unlock the #lock_type_var# #by_the_syn# (k).;check that the #lock_type_var# is unlocked #by_the_syn# (k).;#make_syn_v# that the #lock_type_var# is unlocked #by_the_syn# (k).;insert the (k) into the #lock_type_var#'s lock to unlock it.
+unlock_no_key:unlock the #lock_type_var#.;#make_syn_v# that the #lock_type_var# is unlocked.
+lock:#lock_key#;#lock_no_key#
+lock_key:lock the #lock_type_var# #by_the_syn# (k).;#make_syn_v# that the #lock_type_var# is locked #by_the_syn# (k).;#insert_syn_u# the (k) into the #lock_type_var# to lock it.
+lock_no_key:lock the #lock_type_var#.;#make_syn_v# the #lock_type_var# is locked.;#make_syn_v# that the #lock_type_var# is locked.
+go/north:#go_syn_l# north.;#tryto# #go_syn_l# north.
+go/south:#go_syn_l# south.;#tryto# #go_syn_l# south.
+go/east:#go_syn_l# east.;#tryto# #go_syn_l# east.
+go/west:#go_syn_l# west.;#tryto# #go_syn_l# west.
+go/north/d:#go_syn_l# through the north (d).;#tryto# #go_syn_l# through the north (d).
+go/south/d:#go_syn_l# through the south (d).;#tryto# #go_syn_l# through the south (d).
+go/east/d:#go_syn_l# through the east (d).;#tryto# #go_syn_l# through the east (d).
+go/west/d:#go_syn_l# through the west (d).;#tryto# #go_syn_l# through the west (d).
+go_syn_u:Go;Head;Venture;Travel;Move;Go to the;Take a trip
+go_syn_l:go;head;venture;travel;move;go to the;take a trip
+go_syn_v:visited;travelled;moved;ventured;gone
+tryto:try to;make an effort to;make an attempt to;attempt to
+wait:Wait.
+#action expandables
+#---------------
+
+
+#Compound Command Description Functions
+#----------------
+ig_unlock_open:open the locked #lock_types# using the (k).;unlock and open the #lock_types#.;unlock and open the #lock_types# using the (k).;open the #lock_types# using the (k).
+ig_unlock_open_take:open the locked #lock_types# using the (k) and take the #obj_types_no_key#.;unlock the #lock_types# and take the #obj_types_no_key#.;unlock the #lock_types# using the (k), and take the #obj_types_no_key#.;take the #obj_types_no_key# from within the locked #lock_types#.
+ig_open_take:take the #obj_types# from the (c).;open the (c) and take the #obj_types#.;from in the closed (c), take the #obj_types#.
+ig_take/c_unlock:take the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_take/s_unlock:take the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_take_unlock:#pick-up_synonym_1# the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_open_insert:open the (c) and place the #obj_types# in it.;put the #obj_types# in the closed (c).;
+ig_insert_close:place the #obj_types# in the (c) and close it.;close (c) after placing the #obj_types# in it.
+ig_close_lock:close the #lock_types# and lock it.;close the #lock_types# and lock it with the (k).
+#Flavour Text
+#----------------
+quest:#prologue# (list_of_actions) #epilogue#
+quest_one_action:#prologue_one_action# (action)
+prologue:#welcome#! Here is your task for today. #newsentence#;#welcome#! Here is how to play! #newsentence#;#welcome#! #newsentence#;Hey, thanks for coming over to the TextWorld today, there is something I need you to do for me. #newsentence#
+prologue_one_action:#welcome#! Your task for today is to;#welcome#!;Your objective is to;Hey, thanks for coming over to TextWorld! Please
+newsentence:First off,;First of all,;First stop,;First step,;Your first objective is to;First thing I need you to do is to;First off, if it's not too much trouble, I need you to;First of all, you could, like,;First, it would be #begood# if you could
+action_separator: Then, ; Next, ; Following that, ; If you can #do# that, ; Once you #do# that, ; That done, ; With that over with, ; With that accomplished, ; With that done, ; Okay, and then, ; And then, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+epilogue:Once that's all handled, you can stop!;And once you've done that, you win!;And if you do that, you're the winner!;That's it!;Got that? Good!;Alright, thanks!
+do:manage;do;accomplish;get around to doing;finish;succeed at;get through with
+welcome:Welcome to TextWorld;You are now playing a #exciting# #game# of TextWorld;Welcome to another #exciting# #game# of TextWorld;It's time to explore the amazing world of TextWorld;Get ready to pick stuff up and put it in places, because you've just entered TextWorld;I hope you're ready to go into rooms and interact with objects, because you've just entered TextWorld;Who's got a virtual machine and is about to play through an #exciting# round of TextWorld? You do;
+exciting:exciting;fast paced;life changing;profound
+game:game;round;session;episode
+##Action separators
+##Need at least 5 for each action type
+action_separator_take: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_take/s: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_take/c: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_eat: #afterhave# #ate# the #eat_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_insert: #afterhave# #inserted# the #obj_types# into the (c), ; #after# #inserting# the #obj_types# into the (c), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_put: #afterhave# #put_v# the #obj_types# on the (s), ; #after# #putting# the #obj_types# on the (s), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_open: #afterhave# #opened# the #close_open_types#, ; #after# #opening# the #close_open_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_unlock: #afterhave# #unlocked# the #lock_types#, ; #after# #unlocking# the #lock_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_lock: #afterhave# #locked# the #lock_types#, ; #after# #locking# the #lock_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go: #afterhave# #gone# (dir), ; #after# #getting# (dir), ; once you're (dir), ; once you're in the (dir), ; If you can manage to go (dir), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/south: #afterhave# gone south, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/north: #afterhave# gone north, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/east: #afterhave# gone east, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/west: #afterhave# gone west, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_close: #afterhave# #closed# the #close_open_types#, ; #after# #closing# the #close_open_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_drop: #afterhave# #dropped# the #obj_types#, ; #after# #dropping# the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+#Separator Symbols
+afterhave:After you have;Having;Once you have;If you have
+havetaken:taken;got;picked up
+havepicked-up:taken;got;picked up
+after:After;
+taking:taking;getting;picking up;stealing
+picking-up:taking;getting;picking up;stealing
+ate:ate;consumed
+inserted:inserted;put in
+inserting:inserting;putting in
+put_v:put;place;set;set down
+putting:putting;placing;setting;setting down
+opening:opening;pulling open
+opened:opened;pulled open
+unlocked:unlocked
+unlocking:unlocking
+locked:locked
+locking:locking
+gone:gone;gotten
+getting:going;getting
+closed:closed;shut
+closing:closing;shutting
+dropped:dropped;ditched;tossed;left behind
+dropping:dropping;leaving behind
+
+emptyinstruction1: And then, ;
+emptyinstruction2: Then, ;
+emptyinstruction3: After that, ;
+emptyinstruction4: And then, ;
+emptyinstruction5: After that, ;
+emptyinstruction6: Then, ;
+emptyinstruction7: And then, ;
+emptyinstruction8: After that, ;
+emptyinstruction9: And then, ;
+emptyinstruction10: Then, ;
+

--- a/textworld/challenges/tw_coin_collector/textworld_data/text_grammars/house_obj.twg
+++ b/textworld/challenges/tw_coin_collector/textworld_data/text_grammars/house_obj.twg
@@ -1,0 +1,301 @@
+#-------------------------
+#Object Names Grammar
+#-------------------------
+#all-purpose expandables
+ordinary_adj:ordinary;normal;typical;standard;usual
+adj_stripped:#simpleadj#
+simpleadj:good;bad;small;big;heavy;light;great;terrible;expensive;cheap
+number:0;1;2;3;4;5;6;7;8;9
+#Room Type
+#-------------------
+#list each type of room with a ; between each
+room_type:clean;cook;rest;work;storage
+#Player
+# These values are typically empty
+(P):#(P)_adj# | #(P)_noun#
+(P)_noun:None
+(P)_adj:None
+#Rooms:
+# Each roomType must have specific rooms
+#-------------------
+#Creating a room: first, take the name of the roomtype as listed under #room_type# (which we'll call X for now). create three symbols with this: X_(r), X_(r)_noun, and X_(r)_adj. X_(r) will always be composed of X_(r)_adj | x_(r)_noun. If you want to subdivide a roomtype into two or more variants, you can add _type1, _type2, etc at then end of the noun and adj symbols. make sure that these changes are also accounted for in the X_(r) token, see below for examples
+
+(r):#(r)_adj# | #(r)_noun#
+(r)_noun:washroom;bathroom;cupboard;pantry;basement;closet;kitchen;kitchenette
+(r)_adj:nondescript;plain
+clean_(r):#clean_(r)_adj_type_1# | #clean_(r)_noun_type_1#;#clean_(r)_adj_type_2# | #clean_(r)_noun_type_2#;#clean_(r)_adj_type_3# | #clean_(r)_noun_type_3# ; #clean_(r)_adj_type_4# | #clean_(r)_noun_type_4#
+#Cleaning Self
+clean_(r)_noun_type_1:washroom;bathroom;restroom
+clean_(r)_adj_type_1:spotless;clean;cramped
+#Cleaning stuff
+clean_(r)_noun_type_2:launderette;laundromat;laundry place
+clean_(r)_adj_type_2:spotless;steamy;misty;crowded;cramped;cheap
+#Arguably a room inside a room?
+clean_(r)_noun_type_3:shower
+clean_(r)_adj_type_3:spotless;steamy;misty;marbled
+#Just Saunas
+clean_(r)_noun_type_4:sauna;steam room
+clean_(r)_adj_type_4:spotless;steamy;misty;luxurious;damp
+storage_(r):#storage_(r)_adj# | #storage_(r)_noun#
+storage_(r)_noun:pantry;basement;closet;attic;garage;vault;cellar;spare room
+storage_(r)_adj:spacious;roomy;cramped;stuffed;messy;forgotten;ugly;gloomy
+cook_(r):#cook_(r)_adj# | #cook_(r)_noun#
+cook_(r)_noun:kitchen;kitchenette;canteen;cookery;scullery;cookhouse;dish-pit
+cook_(r)_adj:#hot-adj# hot;steamy;hot;sweaty;balmy
+rest_(r):#rest_(r)_adj_type_1# | #rest_(r)_noun_type_1#;#rest_(r)_adj_type_2# | #rest_(r)_noun_type_2#
+#sleep
+rest_(r)_noun_type_1:bedroom;bedchamber;chamber
+rest_(r)_adj_type_1:cozy;relaxing;pleasant;sleepy
+#fun with friends
+rest_(r)_noun_type_2:lounge;bar;parlor;salon;playroom;recreation zone
+rest_(r)_adj_type_2:fun;entertaining;exciting;well lit
+work_(r):#work_(r)_adj# | #work_(r)_noun#
+work_(r)_noun:office;studio;workshop;cubicle;study
+work_(r)_adj:silent;austere;serious;still
+
+hot-adj:super;unreasonably;absurdly;alarmingly;upsettingly
+#Containers
+# Each roomType must has specific containers
+#container descriptions work like room descriptions, except the (r) is a (c)
+#-------------------
+(c):#(c)_adj_noun#
+(c)_noun:chest;box;safe;locker
+(c)_adj:sturdy;nice;ugly
+(c)_adj_noun:#(c)_adj# | #(c)_noun#
+clean_(c):#clean_(c)_adj_type_1# | #clean_(c)_noun_type_1#;#clean_(c)_adj_type_2# | #clean_(c)_noun_type_2#
+#Type 1
+clean_(c)_noun_type_1:cabinet;basket;box;safe;trunk;case
+clean_(c)_adj_type_1:gross;stained;spotless;plain;
+#Type 2
+clean_(c)_noun_type_2:drawer;dresser;cabinet
+clean_(c)_adj_type_2:#wood_type#wood
+
+storage_(c):#storage_(c)_adj# | #storage_(c)_noun#
+storage_(c)_noun:toolbox;chest;safe;locker;trunk;coffer;cabinet;crate;case;suitcase;display
+storage_(c)_adj:rusty;neglected;brand new
+
+cook_(c):#cook_(c)_adj# | #cook_(c)_noun#
+cook_(c)_noun:fridge;refrigerator;freezer;chest;cabinet;case
+cook_(c)_adj:fancy;big;small
+
+rest_(c):#rest_(c)_adj# | #rest_(c)_noun#
+rest_(c)_noun:dresser;chest;basket;box;safe;locker;trunk;coffer;suitcase;portmanteau
+rest_(c)_adj:new;dusty;clean;amazing
+
+work_(c):#work_(c)_adj# | #work_(c)_noun#
+work_(c)_noun:cabinet;box;safe;locker;trunk;bureau;coffer;case;suitcase;toolbox;portmanteau;display
+work_(c)_adj:iron;rusty;ancient
+
+
+
+fruit:watermelon;melon;honeydew;strawberry;apple;pear;grape;kiwi;cantaloupe
+#Doors
+# Each roomType must has specific doors
+#-------------------
+#Etc Etc, but the (r) is now a (d), and you shouldn't create room specific types
+(d):#(d)_adj# | #(d)_noun#
+(d)_adj:#wood_type#;wooden;stone
+madeof:made of
+wood_type:oak;birch;maple;balsam;beech;mahogany;walnut;cedar;pine;
+(d)_noun:door;portal;gate;passageway;gateway;hatch
+#Supporters
+# Each roomType must has specific supporters
+#-------------------
+#Like containers, but with a (s)
+(s):#(s)_adj# | #(s)_noun#
+(s)_noun:shelf;table;pedestal;slab
+(s)_adj:#(o)_adj#
+clean_(s):#clean_(s)_adj# | #clean_(s)_noun#
+clean_(s)_noun:board;shelf;table;counter;rack;bench
+clean_(s)_adj:dusty;chipped;shiny
+storage_(s):#storage_(s)_adj# | #storage_(s)_noun#
+storage_(s)_noun:shelf;table;workbench;counter;rack;stand
+storage_(s)_adj:rusty;shoddy;splintery;rough
+cook_(s):#cook_(s)_adj# | #cook_(s)_noun#
+cook_(s)_noun:counter;board;shelf;table;rack;chair;plate;bowl;pan;platter;saucepan
+cook_(s)_adj:greasy;soaped down;filthy;messy
+rest_(s):#rest_(s)_adj# | #rest_(s)_noun#
+rest_(s)_noun:bed;couch;shelf;bookshelf;desk;bed stand;mantelpiece;mantle;bar;bench;stand;recliner
+rest_(s)_adj:comfy;warm;worn-out
+work_(s):#work_(s)_adj# | #work_(s)_noun#
+work_(s)_noun:stand;bookshelf;table;chair;shelf;desk;mantelpiece;mantle;stand;armchair
+work_(s)_adj:stern;solid;worn;gross
+
+# Objects
+# Each roomType must have specific objects
+#-------------------
+#(s) --> (o) Very useful to create multiple subtypes to avoid inappropriate or awkward adjective pairing
+(o):#(o)_adj# | #(o)_noun#
+(o)_noun:pencil;pen
+(o)_adj:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;simple;hefty;modest;austere
+#clean objects
+clean_(o):#clean_(o)_adj_type_1# | #clean_(o)_noun_type_1#;#clean_(o)_adj_type_2# | #clean_(o)_noun_type_2#;#clean_(o)_adj_type_3# | #clean_(o)_noun_type_3#;#bugobject#
+clean_(o)_noun:#clean_(o)_noun_type_1#;#clean_(o)_noun_type_2#;#clean_(o)_noun_type_3#
+clean_(o)_adj:#clean_(o)_adj_type_1#;#clean_(o)_adj_type_2#;#clean_(o)_adj_type_3#
+clean_(o)_adj_noun:#clean_(o)_adj_type_1# | #clean_(o)_noun_type_1#;#clean_(o)_adj_type_2# | #clean_(o)_noun_type_2#;#clean_(o)_adj_type_3# | #clean_(o)_noun_type_3#
+#appliances
+clean_(o)_noun_type_1:iron;mop;broom;vacuum
+clean_(o)_adj_type_1:new;old;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;decorated;austere
+#paperproducts
+clean_(o)_noun_type_2:paper towel;sponge
+clean_(o)_adj_type_2:new;old;used;dusty;torn;ripped;dirty;clean;large;small;fancy;plain;ornate;elegant;immaculate;simple;hefty;modest;decorated;austere;embroidered
+#non-disposable
+clean_(o)_noun_type_3:mat;towel;soap dispenser;mop;broom;shirt;sock;sponge
+clean_(o)_adj_type_3:new;old;used;dusty;clean;large;small;fancy;plain;dirty;elegant;tacky
+#storage objects
+storage_(o):#storage_(o)_adj_type_1# | #storage_(o)_noun_type_1#;#storage_(o)_adj_type_2# | #storage_(o)_noun_type_2#;#storage_(o)_adj_type_4# | #storage_(o)_noun_type_4#
+storage_(o)_noun:#storage_(o)_noun_type_1#;#storage_(o)_noun_type_2#;#storage_(o)_noun_type_4#
+storage_(o)_adj:#storage_(o)_adj_type_1#;#storage_(o)_adj_type_2#;#storage_(o)_adj_type_4#
+#clothing
+storage_(o)_noun_type_1:shirt;sock;shoe;glove;hat;scarf;cloak;top hat;pair of pants
+storage_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;contemporary;modern;dirty;elegant;immaculate;simple;modest;gaudy;fashionable;tacky
+#appliances
+storage_(o)_noun_type_2:lightbulb;broom;cane;pair of headphones;lampshade;frisbee;golf #golf#
+storage_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;modern;dirty;elegant;immaculate;simple;hefty;modest;off brand;useless;broken
+golf:club;tee;ball;
+#bugs
+bugobject:#storage_(o)_adj_type_4# | #storage_(o)_noun_type_4#
+storage_(o)_adj_type_4:wriggling;grotesque;repulsive;tiny
+storage_(o)_noun_type_4:worm;fly larva;bug;insect;nest of #bugs#;butterfly;shadfly
+bugs:bugs;insects;spiders;earwigs;beetles;grubs;ticks;kittens;puppies;shrimp;caterpillars;bats;toads;bunnies
+#cook objects
+cook_(o):#cook_(o)_adj_type_1# | #cook_(o)_noun_type_1#;#cook_(o)_adj_type_2# | #cook_(o)_noun_type_2#;#cook_(o)_adj_type_3# | #cook_(o)_noun_type_3#;#bugobject#
+#cook_(o)_adj_type_4# | #cook_(o)_noun_type_4#
+cook_(o)_noun:#cook_(o)_noun_type_1#;#cook_(o)_noun_type_2#;#cook_(o)_noun_type_3#
+#cook_(o)_noun_type_4#
+cook_(o)_adj:#cook_(o)_adj_type_1#;#cook_(o)_adj_type_2#;#cook_(o)_adj_type_3#
+#cook_(o)_adj_type_4#
+#utensil
+cook_(o)_noun_type_1:fork;knife;spoon;spork;teaspoon
+cook_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere;plastic
+#cooking appliance
+cook_(o)_noun_type_2:napkin;whisk;ladle;blender;kettle;teapot
+cook_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere;fancy;broken
+#vessel/plate
+cook_(o)_noun_type_3:mug;bowl;teacup;glass;coffee cup
+cook_(o)_adj_type_3:new;old;used;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;chipped
+#rest objects
+rest_(o):#rest_(o)_adj_type_1# | #rest_(o)_noun_type_1#;#rest_(o)_adj_type_2# | #rest_(o)_noun_type_2#;#rest_(o)_adj_type_3# | #rest_(o)_noun_type_3#;#rest_(o)_adj_type_5# | #rest_(o)_noun_type_5#;#bugobject#
+rest_(o)_noun:#rest_(o)_noun_type_1#;#rest_(o)_noun_type_2#;#rest_(o)_noun_type_3#;#rest_(o)_noun_type_5#
+rest_(o)_adj:#rest_(o)_adj_type_1#;#rest_(o)_adj_type_2#;#rest_(o)_adj_type_3#;#rest_(o)_adj_type_5#
+#screen
+rest_(o)_noun_type_1:tv;laptop;tablet;monitor
+rest_(o)_adj_type_1:shiny;widescreen;shut off;flat-screen
+#electronic
+rest_(o)_noun_type_2:tv;controller;dvd;cd;lamp;laptop;synthesizer
+rest_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;fancy
+#comfortable things
+rest_(o)_noun_type_3:pillow;blanket;plant;cushion
+rest_(o)_adj_type_3:cozy;comfy;comfortable;plush;frilly;nice;small;big;heavy;cute
+#weird book
+rest_(o)_adj_type_5:cool;gigantic;enormous;famous;old
+rest_(o)_noun_type_5:novel;book;manuscript;poem;textbook
+#work objects
+work_(o):#work_(o)_adj_type_1# | #work_(o)_noun_type_1#;#work_(o)_adj_type_2# | #work_(o)_noun_type_2#;#work_(o)_adj_type_3# | #work_(o)_noun_type_3#;#work_(o)_adj_type_4# | #work_(o)_noun_type_4#;#bugobject#
+work_(o)_noun:#work_(o)_noun_type_1#;#work_(o)_noun_type_2#;#work_(o)_noun_type_3#;#work_(o)_noun_type_4#
+work_(o)_adj:#work_(o)_adj_type_1#;#work_(o)_adj_type_2#;#work_(o)_adj_type_3#;#work_(o)_adj_type_4#
+#utensil
+work_(o)_noun_type_1:pen;pencil;staple;mug;disk;cd;book;backup calendar
+work_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;ornate;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere
+#electronic
+work_(o)_noun_type_2:printer;mouse;keyboard;laptop;desktop computer;telephone
+work_(o)_adj_type_2:fancy;broken;operational;working
+#calendar
+work_(o)_noun_type_3:Cat Calendar;Comic Strip Calendar;Quote of the Day Calendar;Advent Calendar
+work_(o)_adj_type_3:heartwarming;hilarious;mind-expanding;out of date;typo-riddled
+#device for using another device
+work_(o)_noun_type_4:stapler;printer;mouse;keyboard;folder;binder
+work_(o)_adj_type_4:operational;broken;expensive;useless;outmoded
+
+
+
+
+# Food
+# Each roomType must have specific food
+#-------------------
+#The below should work as an expandable food pyramid. This can be made room specific.
+
+#Base food
+(f):#(f)_adj# | #(f)_noun#
+(f)_adj:#(f)_adj_good#;#(f)_adj_bad#;#(f)_adj_neutral#
+(f)_noun:#(f)_noun_fruit#;#(f)_noun_vegetable#;#(f)_noun_grain#;#(f)_noun_protein#;#(f)_noun_dairy#;#candy#
+(f)_noun_fruit:#fruit#;apple;banana;grape;coconut;pear;durian;#candy#;#berry#berry;berry
+(f)_noun_vegetable:broccoli;carrot;cucumber;onion;garlic clove;potato;cabbage;cauliflower;pizza;salad
+(f)_noun_grain:loaf of bread;sandwich
+(f)_noun_protein:;legume;cashew;peanut;burger
+(f)_noun_dairy:stick of butter;fondue
+(f)_adj_good:fresh;maturing;soft;chilled;organic
+(f)_adj_bad:aging;half-eaten;rotting
+(f)_adj_neutral:frozen;large;small;massive;tiny;hefty;sizable;dried;dry;pureed
+berry:straw;blue;rasp;black;elder;boysen;lingon;huckle;logan;cran;goji;goose
+
+#Clean food
+#----------
+
+clean_(f):#(f)#
+
+#Storage food
+#------------
+
+storage_(f):#(f)#
+
+#Cook food
+#---------
+
+cook_(f):#(f)#
+
+#Rest food
+#---------
+
+rest_(f):#(f)#
+
+#Work food
+#---------
+
+work_(f):#(f)#
+
+
+candy:chocolate bar;gummy bear;candy bar;licorice strip;cookie
+# Key
+# Each roomType must have specific keys
+#-------------------
+(k):#(k)_adj# | #(k)_noun#
+(k)_adj:iron;brass;metal;rusty;steel;iron;aluminum;copper
+(k)_noun:key;keycard;latchkey;passkey
+#Object Descriptor Functions
+#---------------------------
+(P)_desc:It's you.
+(c)_desc:The (name) looks strong, and impossible to #force_open#.
+force_open:break;crack;destroy
+(s)_desc:The (name) is #supp_stable#.
+supp_stable:stable;wobbly;unstable;balanced;durable;reliable;solid;undependable;solidly built;an unstable piece of #garbage#;shaky
+garbage:garbage;trash;junk
+(o)_desc:The (name) is #obj_what#.;The (name) #looks_seems# #out_in_place# here
+obj_what:unremarkable;clean;dirty;modern;antiquated;well-used;brand new;expensive looking;cheap looking
+looks_seems:looks;seems;appears;appears to be;would seem to be
+out_in_place:out of place;to fit in;well matched to everything else
+restaurant:Burger#place#
+place:town;village;hamlet;burg;ville;City
+(f)_desc:The (name) looks #food_what#.;that's a (name-adj) (name-n)!;You couldn't pay me to eat that (name-adj) thing.
+food_what:appetizing;delicious;tasty;appealing;delectable;heavenly;inviting;savory;tantalizing;tempting
+(k)_desc:The (name) is cold to the touch;The (name) is #key_weight#.;The metal of the (name) is #key_metal#.;The (name) looks useful
+key_weight:heavy;light;weighty;surprisingly heavy;heavier than it looks
+key_metal:antiqued;brushed;hammered;polished;satin;rusty
+(d)_desc:The (name) looks #door_what_is#.;it's a #door_what_is# (name-n);it is what it is, a (name)
+door_what_is:imposing;sturdy;well-built;durable;robust;rugged;hefty;commanding;grand;noble;ominous;towering;manageable;solid;stuffy
+#State descriptors
+#-----------------
+openable_desc:[if open]It is open.[else if closed]It is closed.[otherwise]It is locked.[end if];[if open]You can see inside it.[else if closed]You can't see inside it because the lid's in your way.[otherwise]There is a lock on it.[end if]
+on_desc:On the (name), is [a list of things on the (obj)].;You can see [list of things on the (obj)] on the (name);this (name) has the following upon it, [list of things on the (obj)];you gaze in terror at the [list of things on the (obj)] that lie upon this very (name)!; "now why" you think, "am I looking at [list of things on the (obj)] on this (name)?"
+#Key Match Adjectives
+#These adjectives CANNOT be used elsewhere!
+#----------------
+letter:A;B;C;D;E;F;G;H;I;J;K;L;M;N;O;P;Q;R;S;T;U;V;W;X;Y;Z
+clearancelevel:type #number#;type #letter#;#brand#;#brand#;#brand#;#shape#;#shape#;#shape#;#smell# scented;
+brand:#brandname# style;#brandname# limited edition;#brandname#
+brandname:Microsoft;American;Canadian;Henderson's;TextWorld
+shape:rectangular;cuboid;spherical;formless;non-euclidean
+colour:red;blue;chartreuse;purple;violet;orange;yellow;green;brown;teal;cyan
+smell:vanilla;lavender;cake;fudge;fresh laundry;soap
+(k<->d)_match:#(k)_adj# | #clearancelevel# #(k)_noun# <-> #(d)_adj# | #clearancelevel# #(d)_noun#; #colour# | #(k)_noun# <-> #colour# | #(d)_noun#
+(k<->c)_match:#(k)_adj# | #clearancelevel# #(k)_noun# <-> #(c)_adj# | #clearancelevel# #(c)_noun#; #colour# | #(k)_noun# <-> #colour# | #(c)_noun#

--- a/textworld/challenges/tw_coin_collector/textworld_data/text_grammars/house_room.twg
+++ b/textworld/challenges/tw_coin_collector/textworld_data/text_grammars/house_room.twg
@@ -1,0 +1,451 @@
+#-------------------------
+#Room Descriptor Grammar
+#-------------------------
+
+# Inform7 snippets
+#-----------------
+#Shouldn't need to be messed with. These are shortcuts for when you need to use i7 code. Probably a bad idea to include symbols or tokens inside these
+i7_closed/open:[if (obj) is open]an open[otherwise]a closed[end if]
+i7_list_in:[a list of things in the (obj)]
+i7_list_on:[a list of things on the (obj)]
+i7_empty:[if (obj) contains nothing]an empty[otherwise]a[end if]
+inform7:[if (obj) is locked]a locked[else if (obj) is open]an open[otherwise]a closed[end if]
+inform7A:[if (obj) is locked]A locked[else if (obj) is open]An open[otherwise]A closed[end if]
+inform7noa:[if (obj) is locked]a locked[else if (obj) is open]an open[otherwise]a closed[end if]
+inform7noun:[if (obj) is locked]locked[else if (obj) is open]open[otherwise]closed[end if]
+inform7nounnoa:[if (obj) is locked]locked[else if (obj) is open]open[otherwise]closed[end if]
+
+#Room Intro#
+#----------
+#Text for introducing the room. ex: "Greetings, you are now in the hot kitchen"
+# dec:[if unvisited]#GREETING!# #dec_type##suffix_(r)#[otherwise]#revisit#[end if];[if unvisited]#dec_type##suffix_(r)#[otherwise]#revisit#[end if]
+dec:#dec_type##suffix_(r)#
+
+### First time in room ###
+dec_type:#reg-0#;#normal-0#;#difficult-0#;#moredifficult-0#;#playful-0#
+reg-0:#04#;#05#;#06#
+normal-0:#07#
+difficult-0:#016#
+moredifficult-0:#017#
+playful-0:#01#;#02#;#03#;#08#;#09#;#010#;#011#;#012#;#013#;#014#;#015#;#018#;#019#;#020#;#021#;#022#;#023#;#024#;#025#;#026#;#027#;#028#
+
+### Revisiting room ###
+revisit:You have re-entered the (name).;You re-enter the (name). You're so confused, you need to be reminded what is in the room, even though you were just here seconds ago.;What, you thought if you went somewhere and came back this place would stop being the (name)?;Ah, the (name). You have lots of great memories of this place. Fresh memories. You were just here a second ago.;Well here you are, back in the (name).;Just when you thought you'd never have to see the (name) again, you walk right back into it.;Welcome back to the (name).
+
+#Room Intro Templates
+#-------------------
+
+01:I am sorry to announce that you are now in the (name)
+02:Ah, the (name-n). This is some kind of (name-n), really great (name-adj) vibes in this place, a wonderful (name-adj) atmosphere. And now, well, you're in it
+03:Okay, so you're in a (name-n), cool, but is it (name-adj)? You better believe it is
+04:#dec_find-yourself# in a (name);#dec_guess-what# (name)
+05:Well, here we are in #dec_a_the# (name)
+06:You're now in #dec_a_the# (name)
+07:You've entered a (name);You've just #dec_walked_into# a (name)
+08:This might come as a shock to you, but you've just #dec_entered# a (name)
+09:I am #announce_mood# to announce that you are now in the (name)
+010:Ah, the (name-n). This is some kind of (name-n), really great (name-adj) vibes in this place, a wonderful (name-adj) atmosphere
+011:You have #dec_entered# the most (name-adj) of all possible (name-n)s
+012:Of every (name-n) you could have #dec_walked_into#, you had to #dec_walk_into# a (name-adj) one
+013:You have #dec_entered# a (name-n). Not the (name-n) you'd expect. No, this is a (name)
+014:You are in a (name-n). It seems to be pretty (name-adj) here
+015:You #dec_what# in a (name-adj) kind of place. That is to say, you're in a (name-n)
+016:#dec_find-yourself# in a (name-n). A (name-adj) one
+017:#dec_find-yourself# in a (name-n). A (name-adj) kind of place
+018:#017#
+019:You've #dec_entered# a (name-adj) room. Your mind races to think of what kind of room would be (name-adj). And then it hits you. Of course. You're in the (name)
+020:If you're wondering why everything seems so (name-adj) all of a sudden, it's because you've just #dec_walked_into# the (name)
+021:Fancy seeing you here. Here, by the way, being the (name);I never took you for the sort of person who would show up in a (name), but I guess I was wrong
+022:This is going to sound unbelievable, but you've just entered a (name);You're not going to believe this, but you've just entered a (name)
+023:You make a grand eccentric entrance into a (name);You make another one of your grand eccentric entrances into a (name)
+024:Look at you, bigshot, walking into a (name) like it isn't some huge deal
+025:Look around you. Take it all in. It's not every day someone gets to be in a (name)
+026:You've seen better (name-n)s, but at least this one seems pretty (name-adj);I just think it's awesome that you're in a (name) now;I just think it's great that you've just entered a (name)
+027:A #signquality# #sign# tells you that you are now in the (name);Look at that #sign#! What does it say? It says Welcome to the (name)? Well that's cool
+028:This just in- You, in the (name);Welcome to the (name);Wow! You're in a (name);Here we are in the (name);You've entered a (name);This (name-n) you have just entered is definitely (name-adj)
+#Expandables for Room Symbols
+#----------
+
+GREETING!:GREETING!;GREETINGS!;HELLO!;ALRIGHT THEN!
+dec_entered:entered;walked into;fallen into;moved into;stumbled into;come into
+dec_find-yourself:You #dec_what#
+dec_guess-what:#dec_well-guess#, you are in #dec_a_the# place we're calling #dec_a_the#
+dec_well-guess:Guess what;Well how about that;Well I'll be
+dec_what:are;find yourself;arrive
+dec_a_the:a;the
+dec_in_at:in;at
+dec_walk_into:walk into;show up in;saunter into;come round
+dec_walked_into:walked into;shown up in;sauntered into
+announce_mood:sorry;pleased;excited;stoked;so happy;honoured;required;obligated
+signquality:decrepit;rusty;laminated;crooked;well framed
+sign:sign;placard;notice;signboard;board
+#Description Separators
+#-------
+#Used to separate the description of different object types
+
+#First
+#first:First, you look for (next object type);First, you scan the room for (next object type);You first scan the room for (next object type)
+#Middle
+#middle:After that, you look for (next object type);Once you've ascertained the amount of (previous object type), you start looking for (next object type);
+#Last
+#last:and lastly, you check for (next object type)
+
+#Container Descriptions
+#----------------------
+#Rules for Container Descriptions
+#Good idea to subdivide these into difficulty levels
+#room_desc_(c): generates all container descriptions
+#containerdescription: contains all physical exterior descriptions of containers
+#room_desc_(c)_1_name: describes the container as an adj+noun
+#room_dec_(c)_1_noun: describes the container as a noun
+#room_desc_(c)_content: decides if we append a description of the container's contents depending on if the container is open or closed
+#opencontainer:what is appended if the container is open
+#room_desc_(c)_2_adj: adds an adjective and a list of contents (creates doubled adjectives?)
+#room_desc_(c)_2: list of contents without an adjective
+
+room_desc_(c):#containerdescription##room_desc_(c)_content#
+#special_container#.
+containerdescription:#room_desc_(c)_1_name#;#room_desc_(c)_1_noun#
+room_desc_(c)_content:[if (obj) is open and there is something in the (obj)] #opencontainer##suffix#[end if][if (obj) is open and the (obj) contains nothing] #emptyreaction#[end if]
+opencontainer:The (name) contains #i7_list_in#
+#room_desc_(c)_2_adj#;#room_desc_(c)_2#
+emptyreaction:The (name-n) is empty, what a horrible day!;The (name-n) is empty! What a waste of a day!;The (name-n) is empty! This is the worst thing that could possibly happen, ever!;Empty! What kind of nightmare TextWorld is this?;What a letdown! The (name-n) is empty!
+room_desc_(c)_1_name:#reg-a#;#normal-a#;#difficult-a#;#moredifficult-a#;#playful-a#
+
+reg-a:#a1#;#a2#
+normal-a:#a3#;#a4#;#a5#
+difficult-a:#a6#
+moredifficult-a:#reg-a#
+playful-a:#reg-a#
+
+room_desc_(c)_1_noun:#reg-b#;#normal-b#;#difficult-b#;#moredifficult-b#;#playful-b#
+
+reg-b:#b1#;#b2#
+normal-b:#b3#;#b4#;#b5#
+difficult-b:#reg-b#
+moredifficult-b:#reg-b#
+playful-b:#reg-b#
+
+room_desc_(c)_2_adj:#c1#;#c2#;#c3#;#c4#;#c5#;#c6#;#c7#;#c8#;#c9#
+
+room_desc_(c)_2:#d0#;#d1#;#d2#;#d3#;#d4#
+
+room_desc_(c)_multi_noun:#e1#
+room_desc_(c)_multi_open_noun:#f1#;#f2#;#f3#;#f4#;#f5#;#f6#
+
+room_desc_(c)_multi_adj:#g1#
+room_desc_(c)_multi_open_adj:#h1#;#h2#;#h3#;#h4#
+
+
+
+#Container Description Templates
+#-----------------------------
+
+# A #
+
+a1:#how_see# #inform7# (name).;#a6#
+a2:#how_see# #inform7# #name_var# #here_alt#.;#a6#
+a3:#inform7A# #name_var# is #here_alt#.;#a6#
+a4:#a1#;#a6#
+a5:#a2#;#a6#
+a6:#prefix# (name)#suffix#
+
+# B #
+
+b1:#how_see# #inform7# (name-n).;#b5#
+b2:#how_see# #inform7# (name-n) #here_alt#.;#b5#
+b3:#inform7A# (name-n) is #here_alt#.;#b5#
+b4:#b1#;#b5#
+b5:#prefix# (name-n)#suffix#
+
+# C #
+
+c1:#it_is# (name-adj), and #contains# #i7_list_in#.
+c2:#it_is# (name-adj). Also, there #listwithis# in it.
+c3:#c1#
+c4:#ContentsC-# [list of things in the (obj)].
+c5:there [is|are] [a list of things in the (obj)] in this silly (name-adj) thing.
+c6:#c9#
+c7:#c9#
+c8:Let's see what's inside - #i7_list_in#.
+c9:#it# #reminds_you# the containers #ofyouryouth#. Oh, how they also contained #i7_list_in#.
+
+# D #
+d0:the (name) contains #i7_list_in#.
+d1:It #contains# #i7_list_in#.;There is #i7_list_in# in it.
+d2:There #listwithis# #foundin# it.
+d3:You can see #i7_list_in# in the (name-n).
+d4:In it, you can see #i7_list_in#.
+
+# E #
+
+e1:[if (obj) is open]#room_desc_(c)_multi_open_noun#.[else if (obj) is locked]The (name-n) is locked.[otherwise]The (name-n) is closed.[end if]
+
+# F #
+
+f1:The (name-n) #contains# #i7_list_in#
+f2:There #listwithis# #foundin# the (name-n)
+f3:You can see #i7_list_in# in the (name-n)
+f4:#f5#;#f6#
+f5:#f6#
+f6:The (name-n) #reminds_you# the containers #ofyouryouth#. Oh, how they also contained #i7_list_in#
+
+# G #
+
+g1:[if (obj) is open]#room_desc_(c)_multi_open_adj#.[else if (obj) is locked]The (name-adj) one is locked.[otherwise]The (name-adj) one is closed.[end if]
+
+# H #
+
+h1:The (name-adj) one #contains# #i7_list_in#
+h2:There #i7_list_in# #foundin# the (name-adj) one
+h3:You can see #i7_list_in# in the (name)
+h4:In the (name-adj) one, you can see #i7_list_in#
+
+#Expandables for Container Symbols
+#---------------------------------
+
+it:It;Something about it
+reminds_you:reminds you of;looks like;floods your mind with memories of;is reminiscent of;is just like
+ofyouryouth:of your youth;that you knew in your youth;that you knew so long ago;that you knew so long ago, in your youth
+contains:contains;has;is filled with;reveals inside it;holds;shelters;offers you;reveals to you
+foundin:in;found in
+it_is:It is;You can see that it is;Upon examination, you see that it is
+name_var:(name);(name-n), which looks (name-adj),;(name-adj) looking (name-n)
+contained:contained;held;had;had in it;revealed;concealed;sheltered;offered you;revealed to you;guarded;protected
+inform7:[if (obj) is locked]a locked[else if (obj) is open]an opened[otherwise]a closed[end if]
+inform7noa:[if (obj) is locked]a locked[else if (obj) is open]an opened[otherwise]a closed[end if]
+inform7noun:[if (obj) is locked]locked[else if (obj) is open]opened[otherwise]closed[end if]
+inform7nounnoa:[if (obj) is locked]locked[else if (obj) is open]opened[otherwise]closed[end if]
+listwithis: [is-are a list of things in the (obj)]
+lookthere:Look over there;Wow! look at that
+ContentsC-:Contents-;Contained within-;Inside are the following-;Inventory is as follows-;Here's what's inside
+
+#Supporter Descriptions
+#----------------------
+#Similar to Container descriptions, but without open/close or lock/unlock
+#room_desc_(s): hub
+#room_desc_(s)_1_noun : description of supporter without adjective. Paired with--> room_desc_(s)_2_adj
+#room_desc_(s)_1_name : same as above, but with an adjective
+#room_desc_(s)_2_adj : adjective for supporter plus a list of things on it
+#room_desc_(s)_2:
+
+room_desc_(s):#room_desc_(s)_1_noun# #room_desc_(s)_2_adj#;#room_desc_(s)_1_name# #room_desc_(s)_2#
+
+room_desc_(s)_1_noun:#prefix# (name-n)#suffix_(s)_mid#
+
+room_desc_(s)_1_name:#prefix# (name)#suffix_(s)_mid#
+
+room_desc_(s)_2_adj:The (name-n) is (name-adj).[if there is something on the (obj)] On the (name) #how_see_u# #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)] #emptysupporter##suffix_(s)_end_angry#[end if]
+#;The (name-n) is (name-adj) [if name has something on it] on the (name) #i7_list_on#[else if the (name) is empty]#emptysupporter#[end if]
+
+room_desc_(s)_2:[if there is something on the (obj)]On the (name) #how_see_u# #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter##suffix_(s)_end_angry#[end if];[if there is something on the (obj)]You see #i7_list_on# on the (name-n)#suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter##suffix_(s)_end_angry#[end if]
+#[if name has something on it] on the (name) #i7_list_on#[else if the (name) is empty]#emptysupporter#[end if]
+
+room_desc_(s)_multi_noun:[if there is something on the (obj)]On the (name-n), you see #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter_multi##suffix_(s)_end_angry#[end if]
+room_desc_(s)_multi_adj:[if there is something on the (obj)]On the (name-adj) one, you see #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter_multi##suffix_(s)_end_angry#[end if]
+emptysupporter:But there isn't a thing on it;Unfortunately, there isn't a thing on it;But the thing is empty;But the thing is empty, unfortunately;But the thing hasn't got anything on it;But oh no! there's nothing on this piece of #trash#;The (name-n) appears to be empty;Looks like someone's already been here and taken everything off it, though;However, the (name-n), like an empty (name-n), has nothing on it;
+emptysupporter_multi:There isn't a thing on the (name-n);The (name-n) is empty;Look at the (name-n). There's nothing on this piece of #trash#;But the (name-n) hasn't got anything on it;What a letdown, there's nothing here;
+#Supporter Description Templates
+#-------------------------------
+
+
+
+#Expandables for Supporter Symbols
+#--------------------------------
+
+on_it:on it;lying on it;resting on it;upon it
+ContentsS-:Contents-;Upon it are displayed the following-;Upon it you may see the following-;Upon it lie the following-;Upon the (name-n) are displayed the following-;Upon the (name-n) you may see the following-;Upon the (name-n) lie the following-
+held:held;carried;had;presented;held up;was used to support
+trash:trash;garbage;junk
+#Group Descriptions
+#------------------
+room_desc_group:You can see (^) (val), (name), here#suffix-multi#;Your attention is drawn to (^) (val), (name)#suffix-multi#
+
+#Expandables for Group Description Symbols
+#--------------------------------
+
+this_the:this;the
+room:room;place;part of the game;zone;chamber;area;sector
+
+#Exit Descriptions
+#----------------
+
+#room_desc_(d): describes a single door in the room
+#room_desc_(dir): describes a single unblocked exit in the room
+#room_exit_desc: describes multiple unlocked exits in the room
+#room_desc_exits: possible unnecessary
+#room_desc_doors_closed: describes a group of closed doors in the room
+#room_desc_doors_open: describes a group of open doors in the room
+
+room_desc_(d):There is #i7_closed/open# (name) leading (dir).
+room_desc_(dir):There is an #unblocked# exit to the (dir).;There is an exit to the (dir). Don't worry, it is #unblocked#.;You need an #unblocked# exit? You should try going (dir).;You don't like doors? Why not try going (dir), that entranceway is #unblocked#.
+room_exit_desc:#easy1#.;#medium1#.;#hard1#.
+room_desc_exits:There [is an|are] #unblocked# [exit|exits] to the (dir).
+room_desc_doors_closed:#easy0a#.
+room_desc_doors_open:#easy0b#.
+#[if (name) is open]#room_desc_doors_open#[else if (name) is closed]#room_desc_doors_open#[end if]
+#room_(d)_exit_desc_alt:[If (name) is open]#easy2#[else if (name) closed] closed [end if];[If (name) is open]#medium2#[else if (name) is closed] closed [end if];[If (name) is open]#hard2#[else if (name) is closed] closed [end if]
+#room_(d)_exit_desc:[if (name) is open]#easy3#[else if (name) is closed] closed [end if];[If (name) is open]#medium3#[else if (name) is closed] closed [end if];[If (name) is open]#hard3#[else if (name) is closed]closed[end if]
+
+#Templates for Exit Descriptions
+
+# 0a #
+
+easy0a:There are (^) closed doors, (name-indefinite), here;Let's see how many closed doors there are. Looks like (^), (name-indefinite);There are (^) closed doors here, (name-indefinite);
+
+# 0b #
+
+easy0b:There are (^) open doors, (name-indefinite), here;Let's see how many open doors there are. Looks like (^), (name-indefinite)
+
+# 1 #
+
+easy1:There [is an|are] #unblocked# [exit|exits] to the (dir);There [is an|are] [exit|exits] to the (dir). And hey, don't worry, [they are|it's] #unblocked#
+medium1:[An exit|Exits] #unblocked# [lies|lie] to the (dir);You can go (dir) from here without having to deal with any doors
+hard1:it looks like you can exit to the (dir), if doors aren't really your #yourthing#;if you want to leave, and doors really aren't your #yourthing# you could try going (dir);If you're not really a door person, you could leave by the (dir);If you're not really a doors fan, you could leave by the (dir);not a fan of the doors? Why not go (dir);Hot tip- if you go (dir), you won't have to deal with any doors
+
+
+# 2 #
+
+easy2:#easy21#;#easy22#
+easy21:There [is a door|are doors], #looks# (name-adj), leading (dir);a (name) leads (dir)
+easy22:There is (name-indefinite) leading (dir)
+medium2:You #canshould# see [the door|a door] [at the|blocking the] (dir) [exit|exits]
+hard2:How do you get out? Well, there [is a door|are doors] to the (dir) of you
+
+# 3 #
+
+easy3:The [exit|exits] to the (dir) [is|are] going through (name)
+medium3:The (dir) [exit|exits] [has|have] (name-indefinite) blocking [it|them]
+hard3:The (dir) [exit|exits] [has|have] (name-n-indefinite) blocking [it|them]. the (name-n) [is|are] (name-adj)
+
+#Expandables for Exit Symbols
+#----------------------------
+yourthing:thing;bag;style;cup of tea
+door_what:leading;facing;heading
+unblocked:unblocked;unguarded
+
+#prefixes
+#-----------
+#To be affixed before object descriptions. Keep away from doors. Prefixes start with a uppercase letter and end with "a"
+prefix:You see a gleam over in a corner, where you can see a;What's that over there? It looks like it's a;You scan the room, seeing a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;You smell #smelltype# smell, and follow it to a;Were you looking for a (name-n)? Because look over there, it's a;You rest your hand against a wall, but you miss the wall and fall onto a;You scan the room for a (name-n), and you find a;You hear a noise behind you and spin around, but you can't see anything other than a;Look out! It's a- oh, never mind, it's just a;Look over there! a;Oh, great. Here's a;Hey, want to see a (name-n)? Look over there, a;If you haven't noticed it already, there seems to be something there by the wall, it's a;You bend down to tie your shoe. When you stand up, you notice a;Oh wow! Is that what I think it is? It is! It's a;You lean against the wall, inadvertently pressing a secret button. The wall opens up to reveal a;You see a;As if things weren't amazing enough already, you can even see a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a
+prefix-multi:You see a gleam over in a corner, where you can see ;What's that over there? It looks like it's ;You scan the room, seeing ;#how_see# ;You bend down to tie your shoe. When you stand up, you notice ;You smell #smelltype# smell, and follow it to ;You can suddenly see ;
+prefix_(c):#prefix#
+prefix_(s):#prefix#
+
+#suffixes
+#-----------
+#To be affixed after object descriptions. Keep away from doors. Keep in mind a suffix is usually (but not always) followed by a prefix. Suffixes start with punctuation and end with a period (or exclamation/question mark).
+suffix_meta:. There's something about an object in a room that's just so... TextWorld.;. You can't really describe the (name-n) besides that it's (name-adj).;. Does this look like anything mentioned in the instructions?;. What a great pairing of adjectives and nouns!;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.
+suffix_fulfillment:. A (name-n)... Is that really what you were looking for?;. Is this it? Is this what you came to TextWorld to see? a (name-n)?;. Hmm. You always thought you'd be more excited to see a (name-n) in a room.;. Is this what you came to TextWorld for? This... (name-n)?;. You look around you, at all the containers and supporters, doors and objects, and you think to yourself. Why? Why Textworld?
+suffix_price_schtick:. You check the price tag #pricetagexplain#. #pricebad#?! That's ridiculous! #youknow# my #friendtype#, #myfriend#? I'm sure my friend could get you one of those for #pricegood#!;. You check the price tag #pricetagexplain#. #pricebad#?! That's ridiculous! #Iknow# #afriend# who could get you one of those for #pricegood#!;. You look at the price tag #pricetagexplain#. #pricebad#?! Where'd they buy this (name-n), #expensiveplace#?;. You check the price tag #pricetagexplain#. #pricegood#? What a deal! You'll have to ask where they got this!;. Wow, check out the price tag #pricetagexplain#! #pricebad#!;#emptymain#;#emptymainperiod#
+suffix_(r):. Okay, just remember what you're here to do, and everything will go great.;. You try to gain information on your surroundings by using a technique you call 'looking.';. You can barely contain your excitement.;. The room seems oddly familiar, as though it were only superficially different from the other rooms in the building.;. You decide to just list off a complete list of everything you see in the room, because hey, why not?;. I guess you better just go and list everything you see here.;. You start to take note of what's in the room.;. You decide to start listing off everything you see in the room, as if you were in a text adventure.;. The room is well lit.;. You begin to take stock of what's here.;. You begin to take stock of what's in the room.;. You begin looking for stuff.;. Let's see what's in here.;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#
+### Cut for length ###
+suffix:.;. You shudder, but continue examining the room.;. You wonder idly who left that here.;. Now why would someone leave that there?;. There's something strange about this being here, but you can't put your finger on it.;. There's something strange about this thing being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;!;. Hmmm... what else, what else?;. Wow, isn't TextWorld just the best?;. I mean, just wow! Isn't TextWorld just the best?;. You can't wait to tell the folks at home about this!;. Something scurries by right in the corner of your eye. Probably nothing.;. You idly wonder how they came up with the name TextWorld for this place. It's pretty fitting.;. Suddenly, you bump your head on the ceiling, but it's not such a bad bump that it's going to prevent you from looking at objects and even things.;. Now that's what I call TextWorld!;. Classic TextWorld.;. The light flickers for a second, but nothing else happens.;.;.;.;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty30#;#empty31#;#empty32#;#suffix_price_schtick#;#suffix_fulfillment#;#suffix_meta#
+
+###Multi suffixes need to be more flexible than normal ones###
+suffix-multi:.;. You shudder, but continue examining the room.;. You wonder idly who put this stuff here.;. There's something strange about this stuff being here, but you can't put your finger on it.;. There's something strange about this stuff being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;, so why not take a picture, it'll last longer!;. It doesn't get any more TextWorld than this!;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;
+suffix_(s)_mid:.;. You shudder, but continue examining the (name-n).;. You wonder idly who left that here.;. Now why would someone leave that there?;#suffix_meta#;. Why don't you take a picture of it, it'll last longer!;!;. Wow, isn't TextWorld just the best?;. I guess it's true what they say, if you're looking for a (name-n), go to TextWorld.;. What a coincidence, weren't you just thinking about a (name-n)?;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;
+suffix_(s)_end:.;. You shudder, but continue examining the room.;. There's something strange about this being here, but you can't put your finger on it.;. There's something strange about this thing being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;. Hmmm... what else, what else?;. I mean, just wow! Isn't TextWorld just the best?;. You can't wait to tell the folks at home about this!;. Something scurries by right in the corner of your eye. Probably nothing.;. You idly wonder how they came up with the name TextWorld for this place. It's pretty fitting.;. Suddenly, you bump your head on the ceiling, but it's not such a bad bump that it's going to prevent you from looking at objects and even things.;. Wow! Just like in the movies!;. It doesn't get more TextWorld than this!;. Now that's what I call TextWorld!;. Classic TextWorld.;#suffix#;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;
+suffix_(s)_end_angry:. You move on, clearly #upsetwith# TextWorld.;. You move on, clearly #upsetwith# your TextWorld experience.;. Sometimes, just sometimes, TextWorld can just be the worst.;. What's the point of an empty (name-n)?;. Hopefully this doesn't make you too upset.;. You make a mental note to not get your hopes up the next time you see a (name-n) in a room.;. ;. Hopefully, this discovery doesn't ruin your TextWorld experience!;. You swear loudly.;. This always happens!;. This always happens, here in TextWorld!;. Silly (name-n), silly, empty, good for nothing (name-n).;. You think about smashing the (name-n) to bits, throwing the bits #intheblank#, etc, until you get bored.;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n)! oh well.;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, and here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;#empty46#;#empty47#;#empty48#;#empty49#;#empty50#;
+#fix expandables in
+#-----------
+smelltype:an #ansmell#;a #asmell#
+ansmell:interesting;awful;intriguing
+asmell:hideous;pungent;sickening;terrible;wretched;lovely;great;fine;
+
+upsetwith:upset with;angry about;infuriated by;depressed by;done caring about;upset by;furious with
+pricetagexplain:that's still affixed to the (name-n);that the (name-n)'s owner still hasn't taken off;that hangs off the (name-n);on the (name-n);glued to the (name-n)
+pricebad:#bignumber# dollars;#bignumber# bucks;#bignumber# big ones
+resourcenumber:10;15;20;25;30;35;40;45;50;55;60;65;70;75;80;85;90;95;100
+bignumber:Thirty;Forty;Fifty;Sixty;Seventy;Eighty;Ninety;A hundred;Two hundred;Three hundred
+Iknow:I know a;I got this;I have a;You know, I know a;You know, I got a;You know what, I've got a
+youknow:You know;Do you know;Did you ever meet;You ever meet
+afriend:person, they work out of #friendplace#,;person;friend;person who works for #friendcompany#;person, their #inlaw# works for #cooljob#,
+inlaw:uncle;aunt;sister-in-law;brother-in-law;cousin;other friend;buddy;pal;roommate;dad;mom;brother;sister;neighbour
+myfriend:they work for #friendcompany#
+cooljob:the store;#friendcompany#;the mayor;the president;the prime minister;the internet
+friendplace:the bank;the big city;city hall
+friendcompany:the government;the post office;the mayor;a company
+friendtype:buddy;pal;friend;good friend;
+pricefriend:half that much;half that;six bucks;practically nothing
+pricegood:#resourcenumber# bucks
+expensiveplace:some kind of expensive place;some kind of expensive store
+intheblank:in the dump;in a fire;into a pit;into the garbage
+#General Expandables
+#------------------
+
+canshould:can;should;should be able to;may
+looks:seems to be;looks;seems;appears
+here_alt:here;in the room;nearby;close by;in the corner;right there by you
+here_alt_u:Here;In the room;Nearby;Close by;In the corner;Right there by you
+how_see:You #you_what#;You can #you_what#
+how_see_u:you #you_what#;you can #you_what#
+there_what:is;seems to be
+you_what:see;make out
+
+
+emptymainperiod:#emptymain#
+emptymain:#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;#empty46#;#empty47#;#empty48#;#empty49#;#empty50#;#empty51#;#empty52#;#empty53#;#empty54#;#empty55#;#empty56#;#empty57#;#empty58#;#empty59#;#empty60#;#empty61#;#empty62#;#empty63#
+empty1:.;
+empty2:.;
+empty3:.;
+empty4:.;
+empty5:.;
+empty6:.;
+empty7:.;
+empty8:.;
+empty9:.;
+empty10:.;
+empty11:.;
+empty12:.;
+empty13:.;
+empty14:.;
+empty15:.;
+empty16:.;
+empty17:.;
+empty18:.;
+empty19:.;
+empty20:.;
+empty21:.;
+empty22:.;
+empty23:.;
+empty24:.;
+empty25:.;
+empty26:.;
+empty27:.;
+empty28:.;
+empty29:.;
+empty30:.;
+empty31:.;
+empty32:.;
+empty33:.;
+empty34:.;
+empty35:.;
+empty36:.;
+empty37:.;
+empty38:.;
+empty39:.;
+empty40:.;
+empty41:.;
+empty42:.;
+empty43:.;
+empty44:.;
+empty45:.;
+empty46:.;
+empty47:.;
+empty48:.;
+empty49:.;
+empty50:.;
+empty51:.;
+empty52:.;
+empty53:.;
+empty54:.;
+empty55:.;
+empty56:.;
+empty57:.;
+empty58:.;
+empty59:.;
+empty60:.;
+empty61:.;
+empty62:.;
+empty63:.;

--- a/textworld/challenges/tw_simple/simple.py
+++ b/textworld/challenges/tw_simple/simple.py
@@ -22,16 +22,23 @@ Here's the map of the house.
                Living Room       Garden
 
 """
+
+import os
 import argparse
+from os.path import join as pjoin
 from typing import Mapping, Optional
 
 import textworld
 from textworld.challenges import register
 
 from textworld import GameOptions
+from textworld.generator.data import KnowledgeBase
 from textworld.generator.game import Quest, Event
 
 from textworld.utils import encode_seeds
+
+
+KB_PATH = pjoin(os.path.dirname(__file__), "textworld_data")
 
 
 def build_argparser(parser=None):
@@ -49,7 +56,7 @@ def build_argparser(parser=None):
     return parser
 
 
-def make_game(settings: Mapping[str, str], options: Optional[GameOptions] = None) -> textworld.Game:
+def make(settings: Mapping[str, str], options: Optional[GameOptions] = None) -> textworld.Game:
     """ Make a simple game.
 
     Arguments:
@@ -71,6 +78,9 @@ def make_game(settings: Mapping[str, str], options: Optional[GameOptions] = None
         * test : Whether this game should be drawn from the test
           distributions of games.
     """
+    # Load knowledge base specific to this challenge.
+    options.kb = KnowledgeBase.load(KB_PATH)
+
     metadata = {}  # Collect infos for reproducibility.
     metadata["desc"] = "Simple game"
     metadata["seeds"] = options.seeds
@@ -366,5 +376,5 @@ def make_game(settings: Mapping[str, str], options: Optional[GameOptions] = None
 # Register this simple game.
 register(name="tw-simple",
          desc="Generate simple challenge game",
-         make=make_game,
+         make=make,
          add_arguments=build_argparser)

--- a/textworld/challenges/tw_simple/textworld_data/logic/container.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/container.twl
@@ -1,0 +1,52 @@
+# container
+type c : t {
+    predicates {
+        open(c);
+        closed(c);
+        locked(c);
+
+        in(o, c);
+    }
+
+    rules {
+        lock/c   :: $at(P, r) & $at(c, r) & $in(k, I) & $match(k, c) & closed(c) -> locked(c);
+        unlock/c :: $at(P, r) & $at(c, r) & $in(k, I) & $match(k, c) & locked(c) -> closed(c);
+
+        open/c  :: $at(P, r) & $at(c, r) & closed(c) -> open(c);
+        close/c :: $at(P, r) & $at(c, r) & open(c) -> closed(c);
+    }
+
+    reverse_rules {
+        lock/c :: unlock/c;
+        open/c :: close/c;
+    }
+
+    constraints {
+        c1 :: open(c)   & closed(c) -> fail();
+        c2 :: open(c)   & locked(c) -> fail();
+        c3 :: closed(c) & locked(c) -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "container";
+            definition :: "containers are openable, lockable and fixed in place. containers are usually closed.";
+        }
+
+        predicates {
+            open(c) :: "The {c} is open";
+            closed(c) :: "The {c} is closed";
+            locked(c) :: "The {c} is locked";
+
+            in(o, c) :: "The {o} is in the {c}";
+        }
+
+        commands {
+            open/c :: "open {c}" :: "opening the {c}";
+            close/c :: "close {c}" :: "closing the {c}";
+
+            lock/c :: "lock {c} with {k}" :: "locking the {c} with the {k}";
+            unlock/c :: "unlock {c} with {k}" :: "unlocking the {c} with the {k}";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/door.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/door.twl
@@ -1,0 +1,76 @@
+# door
+type d : t {
+    predicates {
+        open(d);
+        closed(d);
+        locked(d);
+
+        link(r, d, r);
+    }
+
+    rules {
+        lock/d   :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & $in(k, I) & $match(k, d) & closed(d) -> locked(d);
+        unlock/d :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & $in(k, I) & $match(k, d) & locked(d) -> closed(d);
+
+        open/d   :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & closed(d) -> open(d) & free(r, r') & free(r', r);
+        close/d  :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & open(d) & free(r, r') & free(r', r) -> closed(d);
+
+        examine/d :: at(P, r) & $link(r, d, r') -> at(P, r);  # Nothing changes.
+    }
+
+    reverse_rules {
+        lock/d :: unlock/d;
+        open/d :: close/d;
+
+        examine/d :: examine/d;
+    }
+
+    constraints {
+        d1 :: open(d)   & closed(d) -> fail();
+        d2 :: open(d)   & locked(d) -> fail();
+        d3 :: closed(d) & locked(d) -> fail();
+
+        # A door can't be used to link more than two rooms.
+        link1 :: link(r, d, r') & link(r, d, r'') -> fail();
+        link2 :: link(r, d, r') & link(r'', d, r''') -> fail();
+
+        # There's already a door linking two rooms.
+        link3 :: link(r, d, r') & link(r, d', r') -> fail();
+
+        # There cannot be more than four doors in a room.
+        too_many_doors :: link(r, d1: d, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+
+        # There cannot be more than four doors in a room.
+        dr1 :: free(r, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr2 :: free(r, r1: r) & free(r, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr3 :: free(r, r1: r) & free(r, r2: r) & free(r, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr4 :: free(r, r1: r) & free(r, r2: r) & free(r, r3: r) & free(r, r4: r) & link(r, d5: d, r5: r) -> fail();
+
+        free1 :: link(r, d, r') & free(r, r') & closed(d) -> fail();
+        free2 :: link(r, d, r') & free(r, r') & locked(d) -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "door";
+            definition :: "door is openable and lockable.";
+        }
+
+        predicates {
+            open(d) :: "The {d} is open";
+            closed(d) :: "The {d} is closed";
+            locked(d) :: "The {d} is locked";
+            link(r, d, r') :: "";  # No equivalent in Inform7.
+        }
+
+        commands {
+            open/d :: "open {d}" :: "opening {d}";
+            close/d :: "close {d}" :: "closing {d}";
+
+            unlock/d :: "unlock {d} with {k}" :: "unlocking {d} with the {k}";
+            lock/d :: "lock {d} with {k}" :: "locking {d} with the {k}";
+
+            examine/d :: "examine {d}" :: "examining {d}";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/food.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/food.twl
@@ -1,0 +1,34 @@
+# food
+type f : o {
+    predicates {
+        edible(f);
+        eaten(f);
+    }
+
+    rules {
+        eat :: in(f, I) -> eaten(f);
+    }
+
+    constraints {
+        eaten1 :: eaten(f) & in(f, I) -> fail();
+        eaten2 :: eaten(f) & in(f, c) -> fail();
+        eaten3 :: eaten(f) & on(f, s) -> fail();
+        eaten4 :: eaten(f) & at(f, r) -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "food";
+            definition :: "food is edible.";
+        }
+
+        predicates {
+            edible(f) :: "The {f} is edible";
+            eaten(f) :: "The {f} is nowhere";
+        }
+
+        commands {
+            eat :: "eat {f}" :: "eating the {f}";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/inventory.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/inventory.twl
@@ -1,0 +1,58 @@
+# Inventory
+type I {
+    predicates {
+        in(o, I);
+    }
+
+    rules {
+        inventory :: at(P, r) -> at(P, r);  # Nothing changes.
+
+        take :: $at(P, r) & at(o, r) -> in(o, I);
+        drop :: $at(P, r) & in(o, I) -> at(o, r);
+
+        take/c :: $at(P, r) & $at(c, r) & $open(c) & in(o, c) -> in(o, I);
+        insert :: $at(P, r) & $at(c, r) & $open(c) & in(o, I) -> in(o, c);
+
+        take/s :: $at(P, r) & $at(s, r) & on(o, s) -> in(o, I);
+        put    :: $at(P, r) & $at(s, r) & in(o, I) -> on(o, s);
+
+        examine/I :: in(o, I) -> in(o, I);  # Nothing changes.
+        examine/s :: at(P, r) & $at(s, r) & $on(o, s) -> at(P, r);  # Nothing changes.
+        examine/c :: at(P, r) & $at(c, r) & $open(c) & $in(o, c) -> at(P, r);  # Nothing changes.
+    }
+
+    reverse_rules {
+        inventory :: inventory;
+
+        take :: drop;
+        take/c :: insert;
+        take/s :: put;
+
+        examine/I :: examine/I;
+        examine/s :: examine/s;
+        examine/c :: examine/c;
+    }
+
+    inform7 {
+        predicates {
+            in(o, I) :: "The player carries the {o}";
+        }
+
+        commands {
+            take :: "take {o}" :: "taking the {o}";
+            drop :: "drop {o}" :: "dropping the {o}";
+
+            take/c :: "take {o} from {c}" :: "removing the {o} from the {c}";
+            insert :: "insert {o} into {c}" :: "inserting the {o} into the {c}";
+
+            take/s :: "take {o} from {s}" :: "removing the {o} from the {s}";
+            put :: "put {o} on {s}" :: "putting the {o} on the {s}";
+
+            inventory :: "inventory" :: "taking inventory";
+
+            examine/I :: "examine {o}" :: "examining the {o}";
+            examine/s :: "examine {o}" :: "examining the {o}";
+            examine/c :: "examine {o}" :: "examining the {o}";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/key.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/key.twl
@@ -1,0 +1,25 @@
+# key
+type k : o {
+    predicates {
+        match(k, c);
+        match(k, d);
+    }
+
+    constraints {
+        k1 :: match(k, c) & match(k', c) -> fail();
+        k2 :: match(k, c) & match(k, c') -> fail();
+        k3 :: match(k, d) & match(k', d) -> fail();
+        k4 :: match(k, d) & match(k, d') -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "key";
+        }
+
+        predicates {
+            match(k, c) :: "The matching key of the {c} is the {k}";
+            match(k, d) :: "The matching key of the {d} is the {k}";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/object.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/object.twl
@@ -1,0 +1,21 @@
+# object
+type o : t {
+    constraints {
+        obj1 :: in(o, I) & in(o, c) -> fail();
+        obj2 :: in(o, I) & on(o, s) -> fail();
+        obj3 :: in(o, I) & at(o, r) -> fail();
+        obj4 :: in(o, c) & on(o, s) -> fail();
+        obj5 :: in(o, c) & at(o, r) -> fail();
+        obj6 :: on(o, s) & at(o, r) -> fail();
+        obj7 :: at(o, r) & at(o, r') -> fail();
+        obj8 :: in(o, c) & in(o, c') -> fail();
+        obj9 :: on(o, s) & on(o, s') -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "object-like";
+            definition :: "object-like is portable.";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/player.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/player.twl
@@ -1,0 +1,16 @@
+# Player
+type P {
+    rules {
+        look :: at(P, r) -> at(P, r);  # Nothing changes.
+    }
+
+    reverse_rules {
+        look :: look;
+    }
+
+    inform7 {
+        commands {
+            look :: "look" :: "looking";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/room.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/room.twl
@@ -1,0 +1,82 @@
+# room
+type r {
+    predicates {
+        at(P, r);
+        at(t, r);
+
+        north_of(r, r);
+        west_of(r, r);
+
+        north_of/d(r, d, r);
+        west_of/d(r, d, r);
+
+        free(r, r);
+
+        south_of(r, r') = north_of(r', r);
+        east_of(r, r') = west_of(r', r);
+
+        south_of/d(r, d, r') = north_of/d(r', d, r);
+        east_of/d(r, d, r') = west_of/d(r', d, r);
+    }
+
+    rules {
+        go/north :: at(P, r) & $north_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/south :: at(P, r) & $south_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/east  :: at(P, r) & $east_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/west  :: at(P, r) & $west_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+    }
+
+    reverse_rules {
+        go/north :: go/south;
+        go/west :: go/east;
+    }
+
+    constraints {
+        r1 :: at(P, r) & at(P, r') -> fail();
+        r2 :: at(s, r) & at(s, r') -> fail();
+        r3 :: at(c, r) & at(c, r') -> fail();
+
+        # An exit direction can only lead to one room.
+        nav_rr1 :: north_of(r, r') & north_of(r'', r') -> fail();
+        nav_rr2 :: south_of(r, r') & south_of(r'', r') -> fail();
+        nav_rr3 :: east_of(r, r') & east_of(r'', r') -> fail();
+        nav_rr4 :: west_of(r, r') & west_of(r'', r') -> fail();
+
+        # Two rooms can only be connected once with each other.
+        nav_rrA :: north_of(r, r') & south_of(r, r') -> fail();
+        nav_rrB :: north_of(r, r') & west_of(r, r') -> fail();
+        nav_rrC :: north_of(r, r') & east_of(r, r') -> fail();
+        nav_rrD :: south_of(r, r') & west_of(r, r') -> fail();
+        nav_rrE :: south_of(r, r') & east_of(r, r') -> fail();
+        nav_rrF :: west_of(r, r')  & east_of(r, r') -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "room";
+        }
+
+        predicates {
+            at(P, r) :: "The player is in {r}";
+            at(t, r) :: "The {t} is in {r}";
+            free(r, r') :: "";  # No equivalent in Inform7.
+
+            north_of(r, r') :: "The {r} is mapped north of {r'}";
+            south_of(r, r') :: "The {r} is mapped south of {r'}";
+            east_of(r, r') :: "The {r} is mapped east of {r'}";
+            west_of(r, r') :: "The {r} is mapped west of {r'}";
+
+            north_of/d(r, d, r') :: "South of {r} and north of {r'} is a door called {d}";
+            south_of/d(r, d, r') :: "North of {r} and south of {r'} is a door called {d}";
+            east_of/d(r, d, r') :: "West of {r} and east of {r'} is a door called {d}";
+            west_of/d(r, d, r') :: "East of {r} and west of {r'} is a door called {d}";
+        }
+
+        commands {
+            go/north :: "go north" :: "going north";
+            go/south :: "go south" :: "going south";
+            go/east :: "go east" :: "going east";
+            go/west :: "go west" :: "going west";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/supporter.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/supporter.twl
@@ -1,0 +1,17 @@
+# supporter
+type s : t {
+    predicates {
+        on(o, s);
+    }
+
+    inform7 {
+        type {
+            kind :: "supporter";
+            definition :: "supporters are fixed in place.";
+        }
+
+        predicates {
+            on(o, s) :: "The {o} is on the {s}";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/logic/thing.twl
+++ b/textworld/challenges/tw_simple/textworld_data/logic/thing.twl
@@ -1,0 +1,20 @@
+# thing
+type t {
+    rules {
+        examine/t :: at(P, r) & $at(t, r) -> at(P, r);
+    }
+
+    reverse_rules {
+        examine/t :: examine/t;
+    }
+
+    inform7 {
+        type {
+            kind :: "thing";
+        }
+
+        commands {
+            examine/t :: "examine {t}" :: "examining the {t}";
+        }
+    }
+}

--- a/textworld/challenges/tw_simple/textworld_data/text_grammars/house_instruction.twg
+++ b/textworld/challenges/tw_simple/textworld_data/text_grammars/house_instruction.twg
@@ -1,0 +1,154 @@
+#-------------------------
+#Instructions Grammar
+#-------------------------
+obj_types:(o|k|f)
+obj_types_no_key:(o|f)
+on_types:(c|s)
+lock_types:(c|d)
+eat_types:(f)
+close_open_types:(d|c)
+lock_type_var:#lock_types#;#lock_types# #in_the_(r)#
+(s)_var:(s);(s) #in_the_(r)#
+(c)_var:(c);(c) #in_the_(r)#
+on_var:#on_types#;#on_types# #in_the_(r)#
+in_the_(r):in the (r);within the (r);inside the (r)
+make_syn_u:Make sure;Assure;Make it so;Doublecheck;Look and see;Make absolutely sure
+make_syn_v:make sure;assure;make it so;doublecheck;look and see;make absolutely sure
+by_the_syn:with the
+init_syn:in it;inside;placed inside
+into_syn:into;inside
+#actions
+##actions should start with a verb (ie:ensure, make sure, etc (these could probably just be a tag))
+look:look around in (r).
+examine:examine (o|k|f|d|c|s|t).
+inventory:examine your inventory.
+take:#take_synonym_1# the #obj_types# in the (r).;#take_synonym_1# the #obj_types# from the (r).;#take_synonym_1# the #obj_types# that's in the (r).
+take_synonym_1:take;retrieve;recover;pick up
+take/s:#take_synonym_1# the #obj_types# from the #on_var#.
+take/c:#take_synonym_1# the #obj_types# from the #on_var#.
+take:#pick-up_synonym_1# the #obj_types# from the floor of the (r).
+pick-up_synonym_1:pick-up;retrieve;recover;pick up;lift
+pick-up_synonym_v:Pick-up;Retrieve;Recover;Pick up;Lift
+insert:#insert_syn_1# the #obj_types# #into_syn# the #(c)_var#.;you can #insert_syn_1# the #obj_types# #into_syn# the #(c)_var#.
+insert_syn_u:Insert;Put;Place;Deposit
+insert_syn_1:insert;put;place;deposit
+insert_syn_v:inserted;put;placed;deposited
+begood:good;great;fantastic;a great idea
+put:#put_syn_v# the #obj_types# on the #(s)_var#.
+put_syn_u:Put;Place;Sit;Rest
+put_syn_v:put;place;sit;rest
+on_it_syn:on it;upon it
+drop:#drop_syn_v# the #obj_types# on the floor of the (r).
+drop_syn_u:Place
+drop_syn_v:place;drop;ditch;throw;toss;deposit
+eat:#eat_syn_1# the #eat_var#.
+eat_syn_u:Eat;
+eat_syn_1:eat;
+eat_syn_v:eaten;
+open:open the #lock_type_var#.;ensure that the #lock_type_var# is open.;#make_syn_v# that the #lock_type_var# is #open_syn#.
+open_syn:opened;open;wide open;ajar
+close:close the #lock_type_var#.;#make_syn_v# that the #lock_type_var# is #closed_syn#.
+closed_syn:closed;shut
+eat_var:#eat_types#;#eat_types#
+on_var:#on_types#;#on_types# #in_the_(r)#
+unlock:#unlock_key#;#unlock_no_key#
+unlock_key:unlock the #lock_type_var# #by_the_syn# (k).;check that the #lock_type_var# is unlocked #by_the_syn# (k).;#make_syn_v# that the #lock_type_var# is unlocked #by_the_syn# (k).;insert the (k) into the #lock_type_var#'s lock to unlock it.
+unlock_no_key:unlock the #lock_type_var#.;#make_syn_v# that the #lock_type_var# is unlocked.
+lock:#lock_key#;#lock_no_key#
+lock_key:lock the #lock_type_var# #by_the_syn# (k).;#make_syn_v# that the #lock_type_var# is locked #by_the_syn# (k).;#insert_syn_u# the (k) into the #lock_type_var# to lock it.
+lock_no_key:lock the #lock_type_var#.;#make_syn_v# the #lock_type_var# is locked.;#make_syn_v# that the #lock_type_var# is locked.
+go/north:#go_syn_l# north.;#tryto# #go_syn_l# north.
+go/south:#go_syn_l# south.;#tryto# #go_syn_l# south.
+go/east:#go_syn_l# east.;#tryto# #go_syn_l# east.
+go/west:#go_syn_l# west.;#tryto# #go_syn_l# west.
+go/north/d:#go_syn_l# through the north (d).;#tryto# #go_syn_l# through the north (d).
+go/south/d:#go_syn_l# through the south (d).;#tryto# #go_syn_l# through the south (d).
+go/east/d:#go_syn_l# through the east (d).;#tryto# #go_syn_l# through the east (d).
+go/west/d:#go_syn_l# through the west (d).;#tryto# #go_syn_l# through the west (d).
+go_syn_u:Go;Head;Venture;Travel;Move;Go to the;Take a trip
+go_syn_l:go;head;venture;travel;move;go to the;take a trip
+go_syn_v:visited;travelled;moved;ventured;gone
+tryto:try to;make an effort to;make an attempt to;attempt to
+wait:Wait.
+#action expandables
+#---------------
+
+
+#Compound Command Description Functions
+#----------------
+ig_unlock_open:open the locked #lock_types# using the (k).;unlock and open the #lock_types#.;unlock and open the #lock_types# using the (k).;open the #lock_types# using the (k).
+ig_unlock_open_take:open the locked #lock_types# using the (k) and take the #obj_types_no_key#.;unlock the #lock_types# and take the #obj_types_no_key#.;unlock the #lock_types# using the (k), and take the #obj_types_no_key#.;take the #obj_types_no_key# from within the locked #lock_types#.
+ig_open_take:take the #obj_types# from the (c).;open the (c) and take the #obj_types#.;from in the closed (c), take the #obj_types#.
+ig_take/c_unlock:take the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_take/s_unlock:take the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_take_unlock:#pick-up_synonym_1# the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_open_insert:open the (c) and place the #obj_types# in it.;put the #obj_types# in the closed (c).;
+ig_insert_close:place the #obj_types# in the (c) and close it.;close (c) after placing the #obj_types# in it.
+ig_close_lock:close the #lock_types# and lock it.;close the #lock_types# and lock it with the (k).
+#Flavour Text
+#----------------
+quest:#prologue# (list_of_actions) #epilogue#
+quest_one_action:#prologue_one_action# (action)
+prologue:#welcome#! Here is your task for today. #newsentence#;#welcome#! Here is how to play! #newsentence#;#welcome#! #newsentence#;Hey, thanks for coming over to the TextWorld today, there is something I need you to do for me. #newsentence#
+prologue_one_action:#welcome#! Your task for today is to;#welcome#!;Your objective is to;Hey, thanks for coming over to TextWorld! Please
+newsentence:First off,;First of all,;First stop,;First step,;Your first objective is to;First thing I need you to do is to;First off, if it's not too much trouble, I need you to;First of all, you could, like,;First, it would be #begood# if you could
+action_separator: Then, ; Next, ; Following that, ; If you can #do# that, ; Once you #do# that, ; That done, ; With that over with, ; With that accomplished, ; With that done, ; Okay, and then, ; And then, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+epilogue:Once that's all handled, you can stop!;And once you've done that, you win!;And if you do that, you're the winner!;That's it!;Got that? Good!;Alright, thanks!
+do:manage;do;accomplish;get around to doing;finish;succeed at;get through with
+welcome:Welcome to TextWorld;You are now playing a #exciting# #game# of TextWorld;Welcome to another #exciting# #game# of TextWorld;It's time to explore the amazing world of TextWorld;Get ready to pick stuff up and put it in places, because you've just entered TextWorld;I hope you're ready to go into rooms and interact with objects, because you've just entered TextWorld;Who's got a virtual machine and is about to play through an #exciting# round of TextWorld? You do;
+exciting:exciting;fast paced;life changing;profound
+game:game;round;session;episode
+##Action separators
+##Need at least 5 for each action type
+action_separator_take: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_take/s: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_take/c: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_eat: #afterhave# #ate# the #eat_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_insert: #afterhave# #inserted# the #obj_types# into the (c), ; #after# #inserting# the #obj_types# into the (c), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_put: #afterhave# #put_v# the #obj_types# on the (s), ; #after# #putting# the #obj_types# on the (s), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_open: #afterhave# #opened# the #close_open_types#, ; #after# #opening# the #close_open_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_unlock: #afterhave# #unlocked# the #lock_types#, ; #after# #unlocking# the #lock_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_lock: #afterhave# #locked# the #lock_types#, ; #after# #locking# the #lock_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go: #afterhave# #gone# (dir), ; #after# #getting# (dir), ; once you're (dir), ; once you're in the (dir), ; If you can manage to go (dir), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/south: #afterhave# gone south, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/north: #afterhave# gone north, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/east: #afterhave# gone east, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/west: #afterhave# gone west, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_close: #afterhave# #closed# the #close_open_types#, ; #after# #closing# the #close_open_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_drop: #afterhave# #dropped# the #obj_types#, ; #after# #dropping# the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+#Separator Symbols
+afterhave:After you have;Having;Once you have;If you have
+havetaken:taken;got;picked up
+havepicked-up:taken;got;picked up
+after:After;
+taking:taking;getting;picking up;stealing
+picking-up:taking;getting;picking up;stealing
+ate:ate;consumed
+inserted:inserted;put in
+inserting:inserting;putting in
+put_v:put;place;set;set down
+putting:putting;placing;setting;setting down
+opening:opening;pulling open
+opened:opened;pulled open
+unlocked:unlocked
+unlocking:unlocking
+locked:locked
+locking:locking
+gone:gone;gotten
+getting:going;getting
+closed:closed;shut
+closing:closing;shutting
+dropped:dropped;ditched;tossed;left behind
+dropping:dropping;leaving behind
+
+emptyinstruction1: And then, ;
+emptyinstruction2: Then, ;
+emptyinstruction3: After that, ;
+emptyinstruction4: And then, ;
+emptyinstruction5: After that, ;
+emptyinstruction6: Then, ;
+emptyinstruction7: And then, ;
+emptyinstruction8: After that, ;
+emptyinstruction9: And then, ;
+emptyinstruction10: Then, ;
+

--- a/textworld/challenges/tw_simple/textworld_data/text_grammars/house_obj.twg
+++ b/textworld/challenges/tw_simple/textworld_data/text_grammars/house_obj.twg
@@ -1,0 +1,301 @@
+#-------------------------
+#Object Names Grammar
+#-------------------------
+#all-purpose expandables
+ordinary_adj:ordinary;normal;typical;standard;usual
+adj_stripped:#simpleadj#
+simpleadj:good;bad;small;big;heavy;light;great;terrible;expensive;cheap
+number:0;1;2;3;4;5;6;7;8;9
+#Room Type
+#-------------------
+#list each type of room with a ; between each
+room_type:clean;cook;rest;work;storage
+#Player
+# These values are typically empty
+(P):#(P)_adj# | #(P)_noun#
+(P)_noun:None
+(P)_adj:None
+#Rooms:
+# Each roomType must have specific rooms
+#-------------------
+#Creating a room: first, take the name of the roomtype as listed under #room_type# (which we'll call X for now). create three symbols with this: X_(r), X_(r)_noun, and X_(r)_adj. X_(r) will always be composed of X_(r)_adj | x_(r)_noun. If you want to subdivide a roomtype into two or more variants, you can add _type1, _type2, etc at then end of the noun and adj symbols. make sure that these changes are also accounted for in the X_(r) token, see below for examples
+
+(r):#(r)_adj# | #(r)_noun#
+(r)_noun:washroom;bathroom;cupboard;pantry;basement;closet;kitchen;kitchenette
+(r)_adj:nondescript;plain
+clean_(r):#clean_(r)_adj_type_1# | #clean_(r)_noun_type_1#;#clean_(r)_adj_type_2# | #clean_(r)_noun_type_2#;#clean_(r)_adj_type_3# | #clean_(r)_noun_type_3# ; #clean_(r)_adj_type_4# | #clean_(r)_noun_type_4#
+#Cleaning Self
+clean_(r)_noun_type_1:washroom;bathroom;restroom
+clean_(r)_adj_type_1:spotless;clean;cramped
+#Cleaning stuff
+clean_(r)_noun_type_2:launderette;laundromat;laundry place
+clean_(r)_adj_type_2:spotless;steamy;misty;crowded;cramped;cheap
+#Arguably a room inside a room?
+clean_(r)_noun_type_3:shower
+clean_(r)_adj_type_3:spotless;steamy;misty;marbled
+#Just Saunas
+clean_(r)_noun_type_4:sauna;steam room
+clean_(r)_adj_type_4:spotless;steamy;misty;luxurious;damp
+storage_(r):#storage_(r)_adj# | #storage_(r)_noun#
+storage_(r)_noun:pantry;basement;closet;attic;garage;vault;cellar;spare room
+storage_(r)_adj:spacious;roomy;cramped;stuffed;messy;forgotten;ugly;gloomy
+cook_(r):#cook_(r)_adj# | #cook_(r)_noun#
+cook_(r)_noun:kitchen;kitchenette;canteen;cookery;scullery;cookhouse;dish-pit
+cook_(r)_adj:#hot-adj# hot;steamy;hot;sweaty;balmy
+rest_(r):#rest_(r)_adj_type_1# | #rest_(r)_noun_type_1#;#rest_(r)_adj_type_2# | #rest_(r)_noun_type_2#
+#sleep
+rest_(r)_noun_type_1:bedroom;bedchamber;chamber
+rest_(r)_adj_type_1:cozy;relaxing;pleasant;sleepy
+#fun with friends
+rest_(r)_noun_type_2:lounge;bar;parlor;salon;playroom;recreation zone
+rest_(r)_adj_type_2:fun;entertaining;exciting;well lit
+work_(r):#work_(r)_adj# | #work_(r)_noun#
+work_(r)_noun:office;studio;workshop;cubicle;study
+work_(r)_adj:silent;austere;serious;still
+
+hot-adj:super;unreasonably;absurdly;alarmingly;upsettingly
+#Containers
+# Each roomType must has specific containers
+#container descriptions work like room descriptions, except the (r) is a (c)
+#-------------------
+(c):#(c)_adj_noun#
+(c)_noun:chest;box;safe;locker
+(c)_adj:sturdy;nice;ugly
+(c)_adj_noun:#(c)_adj# | #(c)_noun#
+clean_(c):#clean_(c)_adj_type_1# | #clean_(c)_noun_type_1#;#clean_(c)_adj_type_2# | #clean_(c)_noun_type_2#
+#Type 1
+clean_(c)_noun_type_1:cabinet;basket;box;safe;trunk;case
+clean_(c)_adj_type_1:gross;stained;spotless;plain;
+#Type 2
+clean_(c)_noun_type_2:drawer;dresser;cabinet
+clean_(c)_adj_type_2:#wood_type#wood
+
+storage_(c):#storage_(c)_adj# | #storage_(c)_noun#
+storage_(c)_noun:toolbox;chest;safe;locker;trunk;coffer;cabinet;crate;case;suitcase;display
+storage_(c)_adj:rusty;neglected;brand new
+
+cook_(c):#cook_(c)_adj# | #cook_(c)_noun#
+cook_(c)_noun:fridge;refrigerator;freezer;chest;cabinet;case
+cook_(c)_adj:fancy;big;small
+
+rest_(c):#rest_(c)_adj# | #rest_(c)_noun#
+rest_(c)_noun:dresser;chest;basket;box;safe;locker;trunk;coffer;suitcase;portmanteau
+rest_(c)_adj:new;dusty;clean;amazing
+
+work_(c):#work_(c)_adj# | #work_(c)_noun#
+work_(c)_noun:cabinet;box;safe;locker;trunk;bureau;coffer;case;suitcase;toolbox;portmanteau;display
+work_(c)_adj:iron;rusty;ancient
+
+
+
+fruit:watermelon;melon;honeydew;strawberry;apple;pear;grape;kiwi;cantaloupe
+#Doors
+# Each roomType must has specific doors
+#-------------------
+#Etc Etc, but the (r) is now a (d), and you shouldn't create room specific types
+(d):#(d)_adj# | #(d)_noun#
+(d)_adj:#wood_type#;wooden;stone
+madeof:made of
+wood_type:oak;birch;maple;balsam;beech;mahogany;walnut;cedar;pine;
+(d)_noun:door;portal;gate;passageway;gateway;hatch
+#Supporters
+# Each roomType must has specific supporters
+#-------------------
+#Like containers, but with a (s)
+(s):#(s)_adj# | #(s)_noun#
+(s)_noun:shelf;table;pedestal;slab
+(s)_adj:#(o)_adj#
+clean_(s):#clean_(s)_adj# | #clean_(s)_noun#
+clean_(s)_noun:board;shelf;table;counter;rack;bench
+clean_(s)_adj:dusty;chipped;shiny
+storage_(s):#storage_(s)_adj# | #storage_(s)_noun#
+storage_(s)_noun:shelf;table;workbench;counter;rack;stand
+storage_(s)_adj:rusty;shoddy;splintery;rough
+cook_(s):#cook_(s)_adj# | #cook_(s)_noun#
+cook_(s)_noun:counter;board;shelf;table;rack;chair;plate;bowl;pan;platter;saucepan
+cook_(s)_adj:greasy;soaped down;filthy;messy
+rest_(s):#rest_(s)_adj# | #rest_(s)_noun#
+rest_(s)_noun:bed;couch;shelf;bookshelf;desk;bed stand;mantelpiece;mantle;bar;bench;stand;recliner
+rest_(s)_adj:comfy;warm;worn-out
+work_(s):#work_(s)_adj# | #work_(s)_noun#
+work_(s)_noun:stand;bookshelf;table;chair;shelf;desk;mantelpiece;mantle;stand;armchair
+work_(s)_adj:stern;solid;worn;gross
+
+# Objects
+# Each roomType must have specific objects
+#-------------------
+#(s) --> (o) Very useful to create multiple subtypes to avoid inappropriate or awkward adjective pairing
+(o):#(o)_adj# | #(o)_noun#
+(o)_noun:pencil;pen
+(o)_adj:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;simple;hefty;modest;austere
+#clean objects
+clean_(o):#clean_(o)_adj_type_1# | #clean_(o)_noun_type_1#;#clean_(o)_adj_type_2# | #clean_(o)_noun_type_2#;#clean_(o)_adj_type_3# | #clean_(o)_noun_type_3#;#bugobject#
+clean_(o)_noun:#clean_(o)_noun_type_1#;#clean_(o)_noun_type_2#;#clean_(o)_noun_type_3#
+clean_(o)_adj:#clean_(o)_adj_type_1#;#clean_(o)_adj_type_2#;#clean_(o)_adj_type_3#
+clean_(o)_adj_noun:#clean_(o)_adj_type_1# | #clean_(o)_noun_type_1#;#clean_(o)_adj_type_2# | #clean_(o)_noun_type_2#;#clean_(o)_adj_type_3# | #clean_(o)_noun_type_3#
+#appliances
+clean_(o)_noun_type_1:iron;mop;broom;vacuum
+clean_(o)_adj_type_1:new;old;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;decorated;austere
+#paperproducts
+clean_(o)_noun_type_2:paper towel;sponge
+clean_(o)_adj_type_2:new;old;used;dusty;torn;ripped;dirty;clean;large;small;fancy;plain;ornate;elegant;immaculate;simple;hefty;modest;decorated;austere;embroidered
+#non-disposable
+clean_(o)_noun_type_3:mat;towel;soap dispenser;mop;broom;shirt;sock;sponge
+clean_(o)_adj_type_3:new;old;used;dusty;clean;large;small;fancy;plain;dirty;elegant;tacky
+#storage objects
+storage_(o):#storage_(o)_adj_type_1# | #storage_(o)_noun_type_1#;#storage_(o)_adj_type_2# | #storage_(o)_noun_type_2#;#storage_(o)_adj_type_4# | #storage_(o)_noun_type_4#
+storage_(o)_noun:#storage_(o)_noun_type_1#;#storage_(o)_noun_type_2#;#storage_(o)_noun_type_4#
+storage_(o)_adj:#storage_(o)_adj_type_1#;#storage_(o)_adj_type_2#;#storage_(o)_adj_type_4#
+#clothing
+storage_(o)_noun_type_1:shirt;sock;shoe;glove;hat;scarf;cloak;top hat;pair of pants
+storage_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;contemporary;modern;dirty;elegant;immaculate;simple;modest;gaudy;fashionable;tacky
+#appliances
+storage_(o)_noun_type_2:lightbulb;broom;cane;pair of headphones;lampshade;frisbee;golf #golf#
+storage_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;modern;dirty;elegant;immaculate;simple;hefty;modest;off brand;useless;broken
+golf:club;tee;ball;
+#bugs
+bugobject:#storage_(o)_adj_type_4# | #storage_(o)_noun_type_4#
+storage_(o)_adj_type_4:wriggling;grotesque;repulsive;tiny
+storage_(o)_noun_type_4:worm;fly larva;bug;insect;nest of #bugs#;butterfly;shadfly
+bugs:bugs;insects;spiders;earwigs;beetles;grubs;ticks;kittens;puppies;shrimp;caterpillars;bats;toads;bunnies
+#cook objects
+cook_(o):#cook_(o)_adj_type_1# | #cook_(o)_noun_type_1#;#cook_(o)_adj_type_2# | #cook_(o)_noun_type_2#;#cook_(o)_adj_type_3# | #cook_(o)_noun_type_3#;#bugobject#
+#cook_(o)_adj_type_4# | #cook_(o)_noun_type_4#
+cook_(o)_noun:#cook_(o)_noun_type_1#;#cook_(o)_noun_type_2#;#cook_(o)_noun_type_3#
+#cook_(o)_noun_type_4#
+cook_(o)_adj:#cook_(o)_adj_type_1#;#cook_(o)_adj_type_2#;#cook_(o)_adj_type_3#
+#cook_(o)_adj_type_4#
+#utensil
+cook_(o)_noun_type_1:fork;knife;spoon;spork;teaspoon
+cook_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere;plastic
+#cooking appliance
+cook_(o)_noun_type_2:napkin;whisk;ladle;blender;kettle;teapot
+cook_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere;fancy;broken
+#vessel/plate
+cook_(o)_noun_type_3:mug;bowl;teacup;glass;coffee cup
+cook_(o)_adj_type_3:new;old;used;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;chipped
+#rest objects
+rest_(o):#rest_(o)_adj_type_1# | #rest_(o)_noun_type_1#;#rest_(o)_adj_type_2# | #rest_(o)_noun_type_2#;#rest_(o)_adj_type_3# | #rest_(o)_noun_type_3#;#rest_(o)_adj_type_5# | #rest_(o)_noun_type_5#;#bugobject#
+rest_(o)_noun:#rest_(o)_noun_type_1#;#rest_(o)_noun_type_2#;#rest_(o)_noun_type_3#;#rest_(o)_noun_type_5#
+rest_(o)_adj:#rest_(o)_adj_type_1#;#rest_(o)_adj_type_2#;#rest_(o)_adj_type_3#;#rest_(o)_adj_type_5#
+#screen
+rest_(o)_noun_type_1:tv;laptop;tablet;monitor
+rest_(o)_adj_type_1:shiny;widescreen;shut off;flat-screen
+#electronic
+rest_(o)_noun_type_2:tv;controller;dvd;cd;lamp;laptop;synthesizer
+rest_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;fancy
+#comfortable things
+rest_(o)_noun_type_3:pillow;blanket;plant;cushion
+rest_(o)_adj_type_3:cozy;comfy;comfortable;plush;frilly;nice;small;big;heavy;cute
+#weird book
+rest_(o)_adj_type_5:cool;gigantic;enormous;famous;old
+rest_(o)_noun_type_5:novel;book;manuscript;poem;textbook
+#work objects
+work_(o):#work_(o)_adj_type_1# | #work_(o)_noun_type_1#;#work_(o)_adj_type_2# | #work_(o)_noun_type_2#;#work_(o)_adj_type_3# | #work_(o)_noun_type_3#;#work_(o)_adj_type_4# | #work_(o)_noun_type_4#;#bugobject#
+work_(o)_noun:#work_(o)_noun_type_1#;#work_(o)_noun_type_2#;#work_(o)_noun_type_3#;#work_(o)_noun_type_4#
+work_(o)_adj:#work_(o)_adj_type_1#;#work_(o)_adj_type_2#;#work_(o)_adj_type_3#;#work_(o)_adj_type_4#
+#utensil
+work_(o)_noun_type_1:pen;pencil;staple;mug;disk;cd;book;backup calendar
+work_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;ornate;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere
+#electronic
+work_(o)_noun_type_2:printer;mouse;keyboard;laptop;desktop computer;telephone
+work_(o)_adj_type_2:fancy;broken;operational;working
+#calendar
+work_(o)_noun_type_3:Cat Calendar;Comic Strip Calendar;Quote of the Day Calendar;Advent Calendar
+work_(o)_adj_type_3:heartwarming;hilarious;mind-expanding;out of date;typo-riddled
+#device for using another device
+work_(o)_noun_type_4:stapler;printer;mouse;keyboard;folder;binder
+work_(o)_adj_type_4:operational;broken;expensive;useless;outmoded
+
+
+
+
+# Food
+# Each roomType must have specific food
+#-------------------
+#The below should work as an expandable food pyramid. This can be made room specific.
+
+#Base food
+(f):#(f)_adj# | #(f)_noun#
+(f)_adj:#(f)_adj_good#;#(f)_adj_bad#;#(f)_adj_neutral#
+(f)_noun:#(f)_noun_fruit#;#(f)_noun_vegetable#;#(f)_noun_grain#;#(f)_noun_protein#;#(f)_noun_dairy#;#candy#
+(f)_noun_fruit:#fruit#;apple;banana;grape;coconut;pear;durian;#candy#;#berry#berry;berry
+(f)_noun_vegetable:broccoli;carrot;cucumber;onion;garlic clove;potato;cabbage;cauliflower;pizza;salad
+(f)_noun_grain:loaf of bread;sandwich
+(f)_noun_protein:;legume;cashew;peanut;burger
+(f)_noun_dairy:stick of butter;fondue
+(f)_adj_good:fresh;maturing;soft;chilled;organic
+(f)_adj_bad:aging;half-eaten;rotting
+(f)_adj_neutral:frozen;large;small;massive;tiny;hefty;sizable;dried;dry;pureed
+berry:straw;blue;rasp;black;elder;boysen;lingon;huckle;logan;cran;goji;goose
+
+#Clean food
+#----------
+
+clean_(f):#(f)#
+
+#Storage food
+#------------
+
+storage_(f):#(f)#
+
+#Cook food
+#---------
+
+cook_(f):#(f)#
+
+#Rest food
+#---------
+
+rest_(f):#(f)#
+
+#Work food
+#---------
+
+work_(f):#(f)#
+
+
+candy:chocolate bar;gummy bear;candy bar;licorice strip;cookie
+# Key
+# Each roomType must have specific keys
+#-------------------
+(k):#(k)_adj# | #(k)_noun#
+(k)_adj:iron;brass;metal;rusty;steel;iron;aluminum;copper
+(k)_noun:key;keycard;latchkey;passkey
+#Object Descriptor Functions
+#---------------------------
+(P)_desc:It's you.
+(c)_desc:The (name) looks strong, and impossible to #force_open#.
+force_open:break;crack;destroy
+(s)_desc:The (name) is #supp_stable#.
+supp_stable:stable;wobbly;unstable;balanced;durable;reliable;solid;undependable;solidly built;an unstable piece of #garbage#;shaky
+garbage:garbage;trash;junk
+(o)_desc:The (name) is #obj_what#.;The (name) #looks_seems# #out_in_place# here
+obj_what:unremarkable;clean;dirty;modern;antiquated;well-used;brand new;expensive looking;cheap looking
+looks_seems:looks;seems;appears;appears to be;would seem to be
+out_in_place:out of place;to fit in;well matched to everything else
+restaurant:Burger#place#
+place:town;village;hamlet;burg;ville;City
+(f)_desc:The (name) looks #food_what#.;that's a (name-adj) (name-n)!;You couldn't pay me to eat that (name-adj) thing.
+food_what:appetizing;delicious;tasty;appealing;delectable;heavenly;inviting;savory;tantalizing;tempting
+(k)_desc:The (name) is cold to the touch;The (name) is #key_weight#.;The metal of the (name) is #key_metal#.;The (name) looks useful
+key_weight:heavy;light;weighty;surprisingly heavy;heavier than it looks
+key_metal:antiqued;brushed;hammered;polished;satin;rusty
+(d)_desc:The (name) looks #door_what_is#.;it's a #door_what_is# (name-n);it is what it is, a (name)
+door_what_is:imposing;sturdy;well-built;durable;robust;rugged;hefty;commanding;grand;noble;ominous;towering;manageable;solid;stuffy
+#State descriptors
+#-----------------
+openable_desc:[if open]It is open.[else if closed]It is closed.[otherwise]It is locked.[end if];[if open]You can see inside it.[else if closed]You can't see inside it because the lid's in your way.[otherwise]There is a lock on it.[end if]
+on_desc:On the (name), is [a list of things on the (obj)].;You can see [list of things on the (obj)] on the (name);this (name) has the following upon it, [list of things on the (obj)];you gaze in terror at the [list of things on the (obj)] that lie upon this very (name)!; "now why" you think, "am I looking at [list of things on the (obj)] on this (name)?"
+#Key Match Adjectives
+#These adjectives CANNOT be used elsewhere!
+#----------------
+letter:A;B;C;D;E;F;G;H;I;J;K;L;M;N;O;P;Q;R;S;T;U;V;W;X;Y;Z
+clearancelevel:type #number#;type #letter#;#brand#;#brand#;#brand#;#shape#;#shape#;#shape#;#smell# scented;
+brand:#brandname# style;#brandname# limited edition;#brandname#
+brandname:Microsoft;American;Canadian;Henderson's;TextWorld
+shape:rectangular;cuboid;spherical;formless;non-euclidean
+colour:red;blue;chartreuse;purple;violet;orange;yellow;green;brown;teal;cyan
+smell:vanilla;lavender;cake;fudge;fresh laundry;soap
+(k<->d)_match:#(k)_adj# | #clearancelevel# #(k)_noun# <-> #(d)_adj# | #clearancelevel# #(d)_noun#; #colour# | #(k)_noun# <-> #colour# | #(d)_noun#
+(k<->c)_match:#(k)_adj# | #clearancelevel# #(k)_noun# <-> #(c)_adj# | #clearancelevel# #(c)_noun#; #colour# | #(k)_noun# <-> #colour# | #(c)_noun#

--- a/textworld/challenges/tw_simple/textworld_data/text_grammars/house_room.twg
+++ b/textworld/challenges/tw_simple/textworld_data/text_grammars/house_room.twg
@@ -1,0 +1,451 @@
+#-------------------------
+#Room Descriptor Grammar
+#-------------------------
+
+# Inform7 snippets
+#-----------------
+#Shouldn't need to be messed with. These are shortcuts for when you need to use i7 code. Probably a bad idea to include symbols or tokens inside these
+i7_closed/open:[if (obj) is open]an open[otherwise]a closed[end if]
+i7_list_in:[a list of things in the (obj)]
+i7_list_on:[a list of things on the (obj)]
+i7_empty:[if (obj) contains nothing]an empty[otherwise]a[end if]
+inform7:[if (obj) is locked]a locked[else if (obj) is open]an open[otherwise]a closed[end if]
+inform7A:[if (obj) is locked]A locked[else if (obj) is open]An open[otherwise]A closed[end if]
+inform7noa:[if (obj) is locked]a locked[else if (obj) is open]an open[otherwise]a closed[end if]
+inform7noun:[if (obj) is locked]locked[else if (obj) is open]open[otherwise]closed[end if]
+inform7nounnoa:[if (obj) is locked]locked[else if (obj) is open]open[otherwise]closed[end if]
+
+#Room Intro#
+#----------
+#Text for introducing the room. ex: "Greetings, you are now in the hot kitchen"
+# dec:[if unvisited]#GREETING!# #dec_type##suffix_(r)#[otherwise]#revisit#[end if];[if unvisited]#dec_type##suffix_(r)#[otherwise]#revisit#[end if]
+dec:#dec_type##suffix_(r)#
+
+### First time in room ###
+dec_type:#reg-0#;#normal-0#;#difficult-0#;#moredifficult-0#;#playful-0#
+reg-0:#04#;#05#;#06#
+normal-0:#07#
+difficult-0:#016#
+moredifficult-0:#017#
+playful-0:#01#;#02#;#03#;#08#;#09#;#010#;#011#;#012#;#013#;#014#;#015#;#018#;#019#;#020#;#021#;#022#;#023#;#024#;#025#;#026#;#027#;#028#
+
+### Revisiting room ###
+revisit:You have re-entered the (name).;You re-enter the (name). You're so confused, you need to be reminded what is in the room, even though you were just here seconds ago.;What, you thought if you went somewhere and came back this place would stop being the (name)?;Ah, the (name). You have lots of great memories of this place. Fresh memories. You were just here a second ago.;Well here you are, back in the (name).;Just when you thought you'd never have to see the (name) again, you walk right back into it.;Welcome back to the (name).
+
+#Room Intro Templates
+#-------------------
+
+01:I am sorry to announce that you are now in the (name)
+02:Ah, the (name-n). This is some kind of (name-n), really great (name-adj) vibes in this place, a wonderful (name-adj) atmosphere. And now, well, you're in it
+03:Okay, so you're in a (name-n), cool, but is it (name-adj)? You better believe it is
+04:#dec_find-yourself# in a (name);#dec_guess-what# (name)
+05:Well, here we are in #dec_a_the# (name)
+06:You're now in #dec_a_the# (name)
+07:You've entered a (name);You've just #dec_walked_into# a (name)
+08:This might come as a shock to you, but you've just #dec_entered# a (name)
+09:I am #announce_mood# to announce that you are now in the (name)
+010:Ah, the (name-n). This is some kind of (name-n), really great (name-adj) vibes in this place, a wonderful (name-adj) atmosphere
+011:You have #dec_entered# the most (name-adj) of all possible (name-n)s
+012:Of every (name-n) you could have #dec_walked_into#, you had to #dec_walk_into# a (name-adj) one
+013:You have #dec_entered# a (name-n). Not the (name-n) you'd expect. No, this is a (name)
+014:You are in a (name-n). It seems to be pretty (name-adj) here
+015:You #dec_what# in a (name-adj) kind of place. That is to say, you're in a (name-n)
+016:#dec_find-yourself# in a (name-n). A (name-adj) one
+017:#dec_find-yourself# in a (name-n). A (name-adj) kind of place
+018:#017#
+019:You've #dec_entered# a (name-adj) room. Your mind races to think of what kind of room would be (name-adj). And then it hits you. Of course. You're in the (name)
+020:If you're wondering why everything seems so (name-adj) all of a sudden, it's because you've just #dec_walked_into# the (name)
+021:Fancy seeing you here. Here, by the way, being the (name);I never took you for the sort of person who would show up in a (name), but I guess I was wrong
+022:This is going to sound unbelievable, but you've just entered a (name);You're not going to believe this, but you've just entered a (name)
+023:You make a grand eccentric entrance into a (name);You make another one of your grand eccentric entrances into a (name)
+024:Look at you, bigshot, walking into a (name) like it isn't some huge deal
+025:Look around you. Take it all in. It's not every day someone gets to be in a (name)
+026:You've seen better (name-n)s, but at least this one seems pretty (name-adj);I just think it's awesome that you're in a (name) now;I just think it's great that you've just entered a (name)
+027:A #signquality# #sign# tells you that you are now in the (name);Look at that #sign#! What does it say? It says Welcome to the (name)? Well that's cool
+028:This just in- You, in the (name);Welcome to the (name);Wow! You're in a (name);Here we are in the (name);You've entered a (name);This (name-n) you have just entered is definitely (name-adj)
+#Expandables for Room Symbols
+#----------
+
+GREETING!:GREETING!;GREETINGS!;HELLO!;ALRIGHT THEN!
+dec_entered:entered;walked into;fallen into;moved into;stumbled into;come into
+dec_find-yourself:You #dec_what#
+dec_guess-what:#dec_well-guess#, you are in #dec_a_the# place we're calling #dec_a_the#
+dec_well-guess:Guess what;Well how about that;Well I'll be
+dec_what:are;find yourself;arrive
+dec_a_the:a;the
+dec_in_at:in;at
+dec_walk_into:walk into;show up in;saunter into;come round
+dec_walked_into:walked into;shown up in;sauntered into
+announce_mood:sorry;pleased;excited;stoked;so happy;honoured;required;obligated
+signquality:decrepit;rusty;laminated;crooked;well framed
+sign:sign;placard;notice;signboard;board
+#Description Separators
+#-------
+#Used to separate the description of different object types
+
+#First
+#first:First, you look for (next object type);First, you scan the room for (next object type);You first scan the room for (next object type)
+#Middle
+#middle:After that, you look for (next object type);Once you've ascertained the amount of (previous object type), you start looking for (next object type);
+#Last
+#last:and lastly, you check for (next object type)
+
+#Container Descriptions
+#----------------------
+#Rules for Container Descriptions
+#Good idea to subdivide these into difficulty levels
+#room_desc_(c): generates all container descriptions
+#containerdescription: contains all physical exterior descriptions of containers
+#room_desc_(c)_1_name: describes the container as an adj+noun
+#room_dec_(c)_1_noun: describes the container as a noun
+#room_desc_(c)_content: decides if we append a description of the container's contents depending on if the container is open or closed
+#opencontainer:what is appended if the container is open
+#room_desc_(c)_2_adj: adds an adjective and a list of contents (creates doubled adjectives?)
+#room_desc_(c)_2: list of contents without an adjective
+
+room_desc_(c):#containerdescription##room_desc_(c)_content#
+#special_container#.
+containerdescription:#room_desc_(c)_1_name#;#room_desc_(c)_1_noun#
+room_desc_(c)_content:[if (obj) is open and there is something in the (obj)] #opencontainer##suffix#[end if][if (obj) is open and the (obj) contains nothing] #emptyreaction#[end if]
+opencontainer:The (name) contains #i7_list_in#
+#room_desc_(c)_2_adj#;#room_desc_(c)_2#
+emptyreaction:The (name-n) is empty, what a horrible day!;The (name-n) is empty! What a waste of a day!;The (name-n) is empty! This is the worst thing that could possibly happen, ever!;Empty! What kind of nightmare TextWorld is this?;What a letdown! The (name-n) is empty!
+room_desc_(c)_1_name:#reg-a#;#normal-a#;#difficult-a#;#moredifficult-a#;#playful-a#
+
+reg-a:#a1#;#a2#
+normal-a:#a3#;#a4#;#a5#
+difficult-a:#a6#
+moredifficult-a:#reg-a#
+playful-a:#reg-a#
+
+room_desc_(c)_1_noun:#reg-b#;#normal-b#;#difficult-b#;#moredifficult-b#;#playful-b#
+
+reg-b:#b1#;#b2#
+normal-b:#b3#;#b4#;#b5#
+difficult-b:#reg-b#
+moredifficult-b:#reg-b#
+playful-b:#reg-b#
+
+room_desc_(c)_2_adj:#c1#;#c2#;#c3#;#c4#;#c5#;#c6#;#c7#;#c8#;#c9#
+
+room_desc_(c)_2:#d0#;#d1#;#d2#;#d3#;#d4#
+
+room_desc_(c)_multi_noun:#e1#
+room_desc_(c)_multi_open_noun:#f1#;#f2#;#f3#;#f4#;#f5#;#f6#
+
+room_desc_(c)_multi_adj:#g1#
+room_desc_(c)_multi_open_adj:#h1#;#h2#;#h3#;#h4#
+
+
+
+#Container Description Templates
+#-----------------------------
+
+# A #
+
+a1:#how_see# #inform7# (name).;#a6#
+a2:#how_see# #inform7# #name_var# #here_alt#.;#a6#
+a3:#inform7A# #name_var# is #here_alt#.;#a6#
+a4:#a1#;#a6#
+a5:#a2#;#a6#
+a6:#prefix# (name)#suffix#
+
+# B #
+
+b1:#how_see# #inform7# (name-n).;#b5#
+b2:#how_see# #inform7# (name-n) #here_alt#.;#b5#
+b3:#inform7A# (name-n) is #here_alt#.;#b5#
+b4:#b1#;#b5#
+b5:#prefix# (name-n)#suffix#
+
+# C #
+
+c1:#it_is# (name-adj), and #contains# #i7_list_in#.
+c2:#it_is# (name-adj). Also, there #listwithis# in it.
+c3:#c1#
+c4:#ContentsC-# [list of things in the (obj)].
+c5:there [is|are] [a list of things in the (obj)] in this silly (name-adj) thing.
+c6:#c9#
+c7:#c9#
+c8:Let's see what's inside - #i7_list_in#.
+c9:#it# #reminds_you# the containers #ofyouryouth#. Oh, how they also contained #i7_list_in#.
+
+# D #
+d0:the (name) contains #i7_list_in#.
+d1:It #contains# #i7_list_in#.;There is #i7_list_in# in it.
+d2:There #listwithis# #foundin# it.
+d3:You can see #i7_list_in# in the (name-n).
+d4:In it, you can see #i7_list_in#.
+
+# E #
+
+e1:[if (obj) is open]#room_desc_(c)_multi_open_noun#.[else if (obj) is locked]The (name-n) is locked.[otherwise]The (name-n) is closed.[end if]
+
+# F #
+
+f1:The (name-n) #contains# #i7_list_in#
+f2:There #listwithis# #foundin# the (name-n)
+f3:You can see #i7_list_in# in the (name-n)
+f4:#f5#;#f6#
+f5:#f6#
+f6:The (name-n) #reminds_you# the containers #ofyouryouth#. Oh, how they also contained #i7_list_in#
+
+# G #
+
+g1:[if (obj) is open]#room_desc_(c)_multi_open_adj#.[else if (obj) is locked]The (name-adj) one is locked.[otherwise]The (name-adj) one is closed.[end if]
+
+# H #
+
+h1:The (name-adj) one #contains# #i7_list_in#
+h2:There #i7_list_in# #foundin# the (name-adj) one
+h3:You can see #i7_list_in# in the (name)
+h4:In the (name-adj) one, you can see #i7_list_in#
+
+#Expandables for Container Symbols
+#---------------------------------
+
+it:It;Something about it
+reminds_you:reminds you of;looks like;floods your mind with memories of;is reminiscent of;is just like
+ofyouryouth:of your youth;that you knew in your youth;that you knew so long ago;that you knew so long ago, in your youth
+contains:contains;has;is filled with;reveals inside it;holds;shelters;offers you;reveals to you
+foundin:in;found in
+it_is:It is;You can see that it is;Upon examination, you see that it is
+name_var:(name);(name-n), which looks (name-adj),;(name-adj) looking (name-n)
+contained:contained;held;had;had in it;revealed;concealed;sheltered;offered you;revealed to you;guarded;protected
+inform7:[if (obj) is locked]a locked[else if (obj) is open]an opened[otherwise]a closed[end if]
+inform7noa:[if (obj) is locked]a locked[else if (obj) is open]an opened[otherwise]a closed[end if]
+inform7noun:[if (obj) is locked]locked[else if (obj) is open]opened[otherwise]closed[end if]
+inform7nounnoa:[if (obj) is locked]locked[else if (obj) is open]opened[otherwise]closed[end if]
+listwithis: [is-are a list of things in the (obj)]
+lookthere:Look over there;Wow! look at that
+ContentsC-:Contents-;Contained within-;Inside are the following-;Inventory is as follows-;Here's what's inside
+
+#Supporter Descriptions
+#----------------------
+#Similar to Container descriptions, but without open/close or lock/unlock
+#room_desc_(s): hub
+#room_desc_(s)_1_noun : description of supporter without adjective. Paired with--> room_desc_(s)_2_adj
+#room_desc_(s)_1_name : same as above, but with an adjective
+#room_desc_(s)_2_adj : adjective for supporter plus a list of things on it
+#room_desc_(s)_2:
+
+room_desc_(s):#room_desc_(s)_1_noun# #room_desc_(s)_2_adj#;#room_desc_(s)_1_name# #room_desc_(s)_2#
+
+room_desc_(s)_1_noun:#prefix# (name-n)#suffix_(s)_mid#
+
+room_desc_(s)_1_name:#prefix# (name)#suffix_(s)_mid#
+
+room_desc_(s)_2_adj:The (name-n) is (name-adj).[if there is something on the (obj)] On the (name) #how_see_u# #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)] #emptysupporter##suffix_(s)_end_angry#[end if]
+#;The (name-n) is (name-adj) [if name has something on it] on the (name) #i7_list_on#[else if the (name) is empty]#emptysupporter#[end if]
+
+room_desc_(s)_2:[if there is something on the (obj)]On the (name) #how_see_u# #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter##suffix_(s)_end_angry#[end if];[if there is something on the (obj)]You see #i7_list_on# on the (name-n)#suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter##suffix_(s)_end_angry#[end if]
+#[if name has something on it] on the (name) #i7_list_on#[else if the (name) is empty]#emptysupporter#[end if]
+
+room_desc_(s)_multi_noun:[if there is something on the (obj)]On the (name-n), you see #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter_multi##suffix_(s)_end_angry#[end if]
+room_desc_(s)_multi_adj:[if there is something on the (obj)]On the (name-adj) one, you see #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter_multi##suffix_(s)_end_angry#[end if]
+emptysupporter:But there isn't a thing on it;Unfortunately, there isn't a thing on it;But the thing is empty;But the thing is empty, unfortunately;But the thing hasn't got anything on it;But oh no! there's nothing on this piece of #trash#;The (name-n) appears to be empty;Looks like someone's already been here and taken everything off it, though;However, the (name-n), like an empty (name-n), has nothing on it;
+emptysupporter_multi:There isn't a thing on the (name-n);The (name-n) is empty;Look at the (name-n). There's nothing on this piece of #trash#;But the (name-n) hasn't got anything on it;What a letdown, there's nothing here;
+#Supporter Description Templates
+#-------------------------------
+
+
+
+#Expandables for Supporter Symbols
+#--------------------------------
+
+on_it:on it;lying on it;resting on it;upon it
+ContentsS-:Contents-;Upon it are displayed the following-;Upon it you may see the following-;Upon it lie the following-;Upon the (name-n) are displayed the following-;Upon the (name-n) you may see the following-;Upon the (name-n) lie the following-
+held:held;carried;had;presented;held up;was used to support
+trash:trash;garbage;junk
+#Group Descriptions
+#------------------
+room_desc_group:You can see (^) (val), (name), here#suffix-multi#;Your attention is drawn to (^) (val), (name)#suffix-multi#
+
+#Expandables for Group Description Symbols
+#--------------------------------
+
+this_the:this;the
+room:room;place;part of the game;zone;chamber;area;sector
+
+#Exit Descriptions
+#----------------
+
+#room_desc_(d): describes a single door in the room
+#room_desc_(dir): describes a single unblocked exit in the room
+#room_exit_desc: describes multiple unlocked exits in the room
+#room_desc_exits: possible unnecessary
+#room_desc_doors_closed: describes a group of closed doors in the room
+#room_desc_doors_open: describes a group of open doors in the room
+
+room_desc_(d):There is #i7_closed/open# (name) leading (dir).
+room_desc_(dir):There is an #unblocked# exit to the (dir).;There is an exit to the (dir). Don't worry, it is #unblocked#.;You need an #unblocked# exit? You should try going (dir).;You don't like doors? Why not try going (dir), that entranceway is #unblocked#.
+room_exit_desc:#easy1#.;#medium1#.;#hard1#.
+room_desc_exits:There [is an|are] #unblocked# [exit|exits] to the (dir).
+room_desc_doors_closed:#easy0a#.
+room_desc_doors_open:#easy0b#.
+#[if (name) is open]#room_desc_doors_open#[else if (name) is closed]#room_desc_doors_open#[end if]
+#room_(d)_exit_desc_alt:[If (name) is open]#easy2#[else if (name) closed] closed [end if];[If (name) is open]#medium2#[else if (name) is closed] closed [end if];[If (name) is open]#hard2#[else if (name) is closed] closed [end if]
+#room_(d)_exit_desc:[if (name) is open]#easy3#[else if (name) is closed] closed [end if];[If (name) is open]#medium3#[else if (name) is closed] closed [end if];[If (name) is open]#hard3#[else if (name) is closed]closed[end if]
+
+#Templates for Exit Descriptions
+
+# 0a #
+
+easy0a:There are (^) closed doors, (name-indefinite), here;Let's see how many closed doors there are. Looks like (^), (name-indefinite);There are (^) closed doors here, (name-indefinite);
+
+# 0b #
+
+easy0b:There are (^) open doors, (name-indefinite), here;Let's see how many open doors there are. Looks like (^), (name-indefinite)
+
+# 1 #
+
+easy1:There [is an|are] #unblocked# [exit|exits] to the (dir);There [is an|are] [exit|exits] to the (dir). And hey, don't worry, [they are|it's] #unblocked#
+medium1:[An exit|Exits] #unblocked# [lies|lie] to the (dir);You can go (dir) from here without having to deal with any doors
+hard1:it looks like you can exit to the (dir), if doors aren't really your #yourthing#;if you want to leave, and doors really aren't your #yourthing# you could try going (dir);If you're not really a door person, you could leave by the (dir);If you're not really a doors fan, you could leave by the (dir);not a fan of the doors? Why not go (dir);Hot tip- if you go (dir), you won't have to deal with any doors
+
+
+# 2 #
+
+easy2:#easy21#;#easy22#
+easy21:There [is a door|are doors], #looks# (name-adj), leading (dir);a (name) leads (dir)
+easy22:There is (name-indefinite) leading (dir)
+medium2:You #canshould# see [the door|a door] [at the|blocking the] (dir) [exit|exits]
+hard2:How do you get out? Well, there [is a door|are doors] to the (dir) of you
+
+# 3 #
+
+easy3:The [exit|exits] to the (dir) [is|are] going through (name)
+medium3:The (dir) [exit|exits] [has|have] (name-indefinite) blocking [it|them]
+hard3:The (dir) [exit|exits] [has|have] (name-n-indefinite) blocking [it|them]. the (name-n) [is|are] (name-adj)
+
+#Expandables for Exit Symbols
+#----------------------------
+yourthing:thing;bag;style;cup of tea
+door_what:leading;facing;heading
+unblocked:unblocked;unguarded
+
+#prefixes
+#-----------
+#To be affixed before object descriptions. Keep away from doors. Prefixes start with a uppercase letter and end with "a"
+prefix:You see a gleam over in a corner, where you can see a;What's that over there? It looks like it's a;You scan the room, seeing a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;You smell #smelltype# smell, and follow it to a;Were you looking for a (name-n)? Because look over there, it's a;You rest your hand against a wall, but you miss the wall and fall onto a;You scan the room for a (name-n), and you find a;You hear a noise behind you and spin around, but you can't see anything other than a;Look out! It's a- oh, never mind, it's just a;Look over there! a;Oh, great. Here's a;Hey, want to see a (name-n)? Look over there, a;If you haven't noticed it already, there seems to be something there by the wall, it's a;You bend down to tie your shoe. When you stand up, you notice a;Oh wow! Is that what I think it is? It is! It's a;You lean against the wall, inadvertently pressing a secret button. The wall opens up to reveal a;You see a;As if things weren't amazing enough already, you can even see a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a
+prefix-multi:You see a gleam over in a corner, where you can see ;What's that over there? It looks like it's ;You scan the room, seeing ;#how_see# ;You bend down to tie your shoe. When you stand up, you notice ;You smell #smelltype# smell, and follow it to ;You can suddenly see ;
+prefix_(c):#prefix#
+prefix_(s):#prefix#
+
+#suffixes
+#-----------
+#To be affixed after object descriptions. Keep away from doors. Keep in mind a suffix is usually (but not always) followed by a prefix. Suffixes start with punctuation and end with a period (or exclamation/question mark).
+suffix_meta:. There's something about an object in a room that's just so... TextWorld.;. You can't really describe the (name-n) besides that it's (name-adj).;. Does this look like anything mentioned in the instructions?;. What a great pairing of adjectives and nouns!;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.
+suffix_fulfillment:. A (name-n)... Is that really what you were looking for?;. Is this it? Is this what you came to TextWorld to see? a (name-n)?;. Hmm. You always thought you'd be more excited to see a (name-n) in a room.;. Is this what you came to TextWorld for? This... (name-n)?;. You look around you, at all the containers and supporters, doors and objects, and you think to yourself. Why? Why Textworld?
+suffix_price_schtick:. You check the price tag #pricetagexplain#. #pricebad#?! That's ridiculous! #youknow# my #friendtype#, #myfriend#? I'm sure my friend could get you one of those for #pricegood#!;. You check the price tag #pricetagexplain#. #pricebad#?! That's ridiculous! #Iknow# #afriend# who could get you one of those for #pricegood#!;. You look at the price tag #pricetagexplain#. #pricebad#?! Where'd they buy this (name-n), #expensiveplace#?;. You check the price tag #pricetagexplain#. #pricegood#? What a deal! You'll have to ask where they got this!;. Wow, check out the price tag #pricetagexplain#! #pricebad#!;#emptymain#;#emptymainperiod#
+suffix_(r):. Okay, just remember what you're here to do, and everything will go great.;. You try to gain information on your surroundings by using a technique you call 'looking.';. You can barely contain your excitement.;. The room seems oddly familiar, as though it were only superficially different from the other rooms in the building.;. You decide to just list off a complete list of everything you see in the room, because hey, why not?;. I guess you better just go and list everything you see here.;. You start to take note of what's in the room.;. You decide to start listing off everything you see in the room, as if you were in a text adventure.;. The room is well lit.;. You begin to take stock of what's here.;. You begin to take stock of what's in the room.;. You begin looking for stuff.;. Let's see what's in here.;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#
+### Cut for length ###
+suffix:.;. You shudder, but continue examining the room.;. You wonder idly who left that here.;. Now why would someone leave that there?;. There's something strange about this being here, but you can't put your finger on it.;. There's something strange about this thing being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;!;. Hmmm... what else, what else?;. Wow, isn't TextWorld just the best?;. I mean, just wow! Isn't TextWorld just the best?;. You can't wait to tell the folks at home about this!;. Something scurries by right in the corner of your eye. Probably nothing.;. You idly wonder how they came up with the name TextWorld for this place. It's pretty fitting.;. Suddenly, you bump your head on the ceiling, but it's not such a bad bump that it's going to prevent you from looking at objects and even things.;. Now that's what I call TextWorld!;. Classic TextWorld.;. The light flickers for a second, but nothing else happens.;.;.;.;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty30#;#empty31#;#empty32#;#suffix_price_schtick#;#suffix_fulfillment#;#suffix_meta#
+
+###Multi suffixes need to be more flexible than normal ones###
+suffix-multi:.;. You shudder, but continue examining the room.;. You wonder idly who put this stuff here.;. There's something strange about this stuff being here, but you can't put your finger on it.;. There's something strange about this stuff being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;, so why not take a picture, it'll last longer!;. It doesn't get any more TextWorld than this!;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;
+suffix_(s)_mid:.;. You shudder, but continue examining the (name-n).;. You wonder idly who left that here.;. Now why would someone leave that there?;#suffix_meta#;. Why don't you take a picture of it, it'll last longer!;!;. Wow, isn't TextWorld just the best?;. I guess it's true what they say, if you're looking for a (name-n), go to TextWorld.;. What a coincidence, weren't you just thinking about a (name-n)?;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;
+suffix_(s)_end:.;. You shudder, but continue examining the room.;. There's something strange about this being here, but you can't put your finger on it.;. There's something strange about this thing being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;. Hmmm... what else, what else?;. I mean, just wow! Isn't TextWorld just the best?;. You can't wait to tell the folks at home about this!;. Something scurries by right in the corner of your eye. Probably nothing.;. You idly wonder how they came up with the name TextWorld for this place. It's pretty fitting.;. Suddenly, you bump your head on the ceiling, but it's not such a bad bump that it's going to prevent you from looking at objects and even things.;. Wow! Just like in the movies!;. It doesn't get more TextWorld than this!;. Now that's what I call TextWorld!;. Classic TextWorld.;#suffix#;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;
+suffix_(s)_end_angry:. You move on, clearly #upsetwith# TextWorld.;. You move on, clearly #upsetwith# your TextWorld experience.;. Sometimes, just sometimes, TextWorld can just be the worst.;. What's the point of an empty (name-n)?;. Hopefully this doesn't make you too upset.;. You make a mental note to not get your hopes up the next time you see a (name-n) in a room.;. ;. Hopefully, this discovery doesn't ruin your TextWorld experience!;. You swear loudly.;. This always happens!;. This always happens, here in TextWorld!;. Silly (name-n), silly, empty, good for nothing (name-n).;. You think about smashing the (name-n) to bits, throwing the bits #intheblank#, etc, until you get bored.;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n)! oh well.;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, and here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;#empty46#;#empty47#;#empty48#;#empty49#;#empty50#;
+#fix expandables in
+#-----------
+smelltype:an #ansmell#;a #asmell#
+ansmell:interesting;awful;intriguing
+asmell:hideous;pungent;sickening;terrible;wretched;lovely;great;fine;
+
+upsetwith:upset with;angry about;infuriated by;depressed by;done caring about;upset by;furious with
+pricetagexplain:that's still affixed to the (name-n);that the (name-n)'s owner still hasn't taken off;that hangs off the (name-n);on the (name-n);glued to the (name-n)
+pricebad:#bignumber# dollars;#bignumber# bucks;#bignumber# big ones
+resourcenumber:10;15;20;25;30;35;40;45;50;55;60;65;70;75;80;85;90;95;100
+bignumber:Thirty;Forty;Fifty;Sixty;Seventy;Eighty;Ninety;A hundred;Two hundred;Three hundred
+Iknow:I know a;I got this;I have a;You know, I know a;You know, I got a;You know what, I've got a
+youknow:You know;Do you know;Did you ever meet;You ever meet
+afriend:person, they work out of #friendplace#,;person;friend;person who works for #friendcompany#;person, their #inlaw# works for #cooljob#,
+inlaw:uncle;aunt;sister-in-law;brother-in-law;cousin;other friend;buddy;pal;roommate;dad;mom;brother;sister;neighbour
+myfriend:they work for #friendcompany#
+cooljob:the store;#friendcompany#;the mayor;the president;the prime minister;the internet
+friendplace:the bank;the big city;city hall
+friendcompany:the government;the post office;the mayor;a company
+friendtype:buddy;pal;friend;good friend;
+pricefriend:half that much;half that;six bucks;practically nothing
+pricegood:#resourcenumber# bucks
+expensiveplace:some kind of expensive place;some kind of expensive store
+intheblank:in the dump;in a fire;into a pit;into the garbage
+#General Expandables
+#------------------
+
+canshould:can;should;should be able to;may
+looks:seems to be;looks;seems;appears
+here_alt:here;in the room;nearby;close by;in the corner;right there by you
+here_alt_u:Here;In the room;Nearby;Close by;In the corner;Right there by you
+how_see:You #you_what#;You can #you_what#
+how_see_u:you #you_what#;you can #you_what#
+there_what:is;seems to be
+you_what:see;make out
+
+
+emptymainperiod:#emptymain#
+emptymain:#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;#empty46#;#empty47#;#empty48#;#empty49#;#empty50#;#empty51#;#empty52#;#empty53#;#empty54#;#empty55#;#empty56#;#empty57#;#empty58#;#empty59#;#empty60#;#empty61#;#empty62#;#empty63#
+empty1:.;
+empty2:.;
+empty3:.;
+empty4:.;
+empty5:.;
+empty6:.;
+empty7:.;
+empty8:.;
+empty9:.;
+empty10:.;
+empty11:.;
+empty12:.;
+empty13:.;
+empty14:.;
+empty15:.;
+empty16:.;
+empty17:.;
+empty18:.;
+empty19:.;
+empty20:.;
+empty21:.;
+empty22:.;
+empty23:.;
+empty24:.;
+empty25:.;
+empty26:.;
+empty27:.;
+empty28:.;
+empty29:.;
+empty30:.;
+empty31:.;
+empty32:.;
+empty33:.;
+empty34:.;
+empty35:.;
+empty36:.;
+empty37:.;
+empty38:.;
+empty39:.;
+empty40:.;
+empty41:.;
+empty42:.;
+empty43:.;
+empty44:.;
+empty45:.;
+empty46:.;
+empty47:.;
+empty48:.;
+empty49:.;
+empty50:.;
+empty51:.;
+empty52:.;
+empty53:.;
+empty54:.;
+empty55:.;
+empty56:.;
+empty57:.;
+empty58:.;
+empty59:.;
+empty60:.;
+empty61:.;
+empty62:.;
+empty63:.;

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/container.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/container.twl
@@ -1,0 +1,52 @@
+# container
+type c : t {
+    predicates {
+        open(c);
+        closed(c);
+        locked(c);
+
+        in(o, c);
+    }
+
+    rules {
+        lock/c   :: $at(P, r) & $at(c, r) & $in(k, I) & $match(k, c) & closed(c) -> locked(c);
+        unlock/c :: $at(P, r) & $at(c, r) & $in(k, I) & $match(k, c) & locked(c) -> closed(c);
+
+        open/c  :: $at(P, r) & $at(c, r) & closed(c) -> open(c);
+        close/c :: $at(P, r) & $at(c, r) & open(c) -> closed(c);
+    }
+
+    reverse_rules {
+        lock/c :: unlock/c;
+        open/c :: close/c;
+    }
+
+    constraints {
+        c1 :: open(c)   & closed(c) -> fail();
+        c2 :: open(c)   & locked(c) -> fail();
+        c3 :: closed(c) & locked(c) -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "container";
+            definition :: "containers are openable, lockable and fixed in place. containers are usually closed.";
+        }
+
+        predicates {
+            open(c) :: "The {c} is open";
+            closed(c) :: "The {c} is closed";
+            locked(c) :: "The {c} is locked";
+
+            in(o, c) :: "The {o} is in the {c}";
+        }
+
+        commands {
+            open/c :: "open {c}" :: "opening the {c}";
+            close/c :: "close {c}" :: "closing the {c}";
+
+            lock/c :: "lock {c} with {k}" :: "locking the {c} with the {k}";
+            unlock/c :: "unlock {c} with {k}" :: "unlocking the {c} with the {k}";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/door.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/door.twl
@@ -1,0 +1,76 @@
+# door
+type d : t {
+    predicates {
+        open(d);
+        closed(d);
+        locked(d);
+
+        link(r, d, r);
+    }
+
+    rules {
+        lock/d   :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & $in(k, I) & $match(k, d) & closed(d) -> locked(d);
+        unlock/d :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & $in(k, I) & $match(k, d) & locked(d) -> closed(d);
+
+        open/d   :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & closed(d) -> open(d) & free(r, r') & free(r', r);
+        close/d  :: $at(P, r) & $link(r, d, r') & $link(r', d, r) & open(d) & free(r, r') & free(r', r) -> closed(d);
+
+        examine/d :: at(P, r) & $link(r, d, r') -> at(P, r);  # Nothing changes.
+    }
+
+    reverse_rules {
+        lock/d :: unlock/d;
+        open/d :: close/d;
+
+        examine/d :: examine/d;
+    }
+
+    constraints {
+        d1 :: open(d)   & closed(d) -> fail();
+        d2 :: open(d)   & locked(d) -> fail();
+        d3 :: closed(d) & locked(d) -> fail();
+
+        # A door can't be used to link more than two rooms.
+        link1 :: link(r, d, r') & link(r, d, r'') -> fail();
+        link2 :: link(r, d, r') & link(r'', d, r''') -> fail();
+
+        # There's already a door linking two rooms.
+        link3 :: link(r, d, r') & link(r, d', r') -> fail();
+
+        # There cannot be more than four doors in a room.
+        too_many_doors :: link(r, d1: d, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+
+        # There cannot be more than four doors in a room.
+        dr1 :: free(r, r1: r) & link(r, d2: d, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr2 :: free(r, r1: r) & free(r, r2: r) & link(r, d3: d, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr3 :: free(r, r1: r) & free(r, r2: r) & free(r, r3: r) & link(r, d4: d, r4: r) & link(r, d5: d, r5: r) -> fail();
+        dr4 :: free(r, r1: r) & free(r, r2: r) & free(r, r3: r) & free(r, r4: r) & link(r, d5: d, r5: r) -> fail();
+
+        free1 :: link(r, d, r') & free(r, r') & closed(d) -> fail();
+        free2 :: link(r, d, r') & free(r, r') & locked(d) -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "door";
+            definition :: "door is openable and lockable.";
+        }
+
+        predicates {
+            open(d) :: "The {d} is open";
+            closed(d) :: "The {d} is closed";
+            locked(d) :: "The {d} is locked";
+            link(r, d, r') :: "";  # No equivalent in Inform7.
+        }
+
+        commands {
+            open/d :: "open {d}" :: "opening {d}";
+            close/d :: "close {d}" :: "closing {d}";
+
+            unlock/d :: "unlock {d} with {k}" :: "unlocking {d} with the {k}";
+            lock/d :: "lock {d} with {k}" :: "locking {d} with the {k}";
+
+            examine/d :: "examine {d}" :: "examining {d}";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/food.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/food.twl
@@ -1,0 +1,34 @@
+# food
+type f : o {
+    predicates {
+        edible(f);
+        eaten(f);
+    }
+
+    rules {
+        eat :: in(f, I) -> eaten(f);
+    }
+
+    constraints {
+        eaten1 :: eaten(f) & in(f, I) -> fail();
+        eaten2 :: eaten(f) & in(f, c) -> fail();
+        eaten3 :: eaten(f) & on(f, s) -> fail();
+        eaten4 :: eaten(f) & at(f, r) -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "food";
+            definition :: "food is edible.";
+        }
+
+        predicates {
+            edible(f) :: "The {f} is edible";
+            eaten(f) :: "The {f} is nowhere";
+        }
+
+        commands {
+            eat :: "eat {f}" :: "eating the {f}";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/inventory.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/inventory.twl
@@ -1,0 +1,58 @@
+# Inventory
+type I {
+    predicates {
+        in(o, I);
+    }
+
+    rules {
+        inventory :: at(P, r) -> at(P, r);  # Nothing changes.
+
+        take :: $at(P, r) & at(o, r) -> in(o, I);
+        drop :: $at(P, r) & in(o, I) -> at(o, r);
+
+        take/c :: $at(P, r) & $at(c, r) & $open(c) & in(o, c) -> in(o, I);
+        insert :: $at(P, r) & $at(c, r) & $open(c) & in(o, I) -> in(o, c);
+
+        take/s :: $at(P, r) & $at(s, r) & on(o, s) -> in(o, I);
+        put    :: $at(P, r) & $at(s, r) & in(o, I) -> on(o, s);
+
+        examine/I :: in(o, I) -> in(o, I);  # Nothing changes.
+        examine/s :: at(P, r) & $at(s, r) & $on(o, s) -> at(P, r);  # Nothing changes.
+        examine/c :: at(P, r) & $at(c, r) & $open(c) & $in(o, c) -> at(P, r);  # Nothing changes.
+    }
+
+    reverse_rules {
+        inventory :: inventory;
+
+        take :: drop;
+        take/c :: insert;
+        take/s :: put;
+
+        examine/I :: examine/I;
+        examine/s :: examine/s;
+        examine/c :: examine/c;
+    }
+
+    inform7 {
+        predicates {
+            in(o, I) :: "The player carries the {o}";
+        }
+
+        commands {
+            take :: "take {o}" :: "taking the {o}";
+            drop :: "drop {o}" :: "dropping the {o}";
+
+            take/c :: "take {o} from {c}" :: "removing the {o} from the {c}";
+            insert :: "insert {o} into {c}" :: "inserting the {o} into the {c}";
+
+            take/s :: "take {o} from {s}" :: "removing the {o} from the {s}";
+            put :: "put {o} on {s}" :: "putting the {o} on the {s}";
+
+            inventory :: "inventory" :: "taking inventory";
+
+            examine/I :: "examine {o}" :: "examining the {o}";
+            examine/s :: "examine {o}" :: "examining the {o}";
+            examine/c :: "examine {o}" :: "examining the {o}";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/key.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/key.twl
@@ -1,0 +1,25 @@
+# key
+type k : o {
+    predicates {
+        match(k, c);
+        match(k, d);
+    }
+
+    constraints {
+        k1 :: match(k, c) & match(k', c) -> fail();
+        k2 :: match(k, c) & match(k, c') -> fail();
+        k3 :: match(k, d) & match(k', d) -> fail();
+        k4 :: match(k, d) & match(k, d') -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "key";
+        }
+
+        predicates {
+            match(k, c) :: "The matching key of the {c} is the {k}";
+            match(k, d) :: "The matching key of the {d} is the {k}";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/object.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/object.twl
@@ -1,0 +1,21 @@
+# object
+type o : t {
+    constraints {
+        obj1 :: in(o, I) & in(o, c) -> fail();
+        obj2 :: in(o, I) & on(o, s) -> fail();
+        obj3 :: in(o, I) & at(o, r) -> fail();
+        obj4 :: in(o, c) & on(o, s) -> fail();
+        obj5 :: in(o, c) & at(o, r) -> fail();
+        obj6 :: on(o, s) & at(o, r) -> fail();
+        obj7 :: at(o, r) & at(o, r') -> fail();
+        obj8 :: in(o, c) & in(o, c') -> fail();
+        obj9 :: on(o, s) & on(o, s') -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "object-like";
+            definition :: "object-like is portable.";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/player.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/player.twl
@@ -1,0 +1,16 @@
+# Player
+type P {
+    rules {
+        look :: at(P, r) -> at(P, r);  # Nothing changes.
+    }
+
+    reverse_rules {
+        look :: look;
+    }
+
+    inform7 {
+        commands {
+            look :: "look" :: "looking";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/room.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/room.twl
@@ -1,0 +1,82 @@
+# room
+type r {
+    predicates {
+        at(P, r);
+        at(t, r);
+
+        north_of(r, r);
+        west_of(r, r);
+
+        north_of/d(r, d, r);
+        west_of/d(r, d, r);
+
+        free(r, r);
+
+        south_of(r, r') = north_of(r', r);
+        east_of(r, r') = west_of(r', r);
+
+        south_of/d(r, d, r') = north_of/d(r', d, r);
+        east_of/d(r, d, r') = west_of/d(r', d, r);
+    }
+
+    rules {
+        go/north :: at(P, r) & $north_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/south :: at(P, r) & $south_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/east  :: at(P, r) & $east_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+        go/west  :: at(P, r) & $west_of(r', r) & $free(r, r') & $free(r', r) -> at(P, r');
+    }
+
+    reverse_rules {
+        go/north :: go/south;
+        go/west :: go/east;
+    }
+
+    constraints {
+        r1 :: at(P, r) & at(P, r') -> fail();
+        r2 :: at(s, r) & at(s, r') -> fail();
+        r3 :: at(c, r) & at(c, r') -> fail();
+
+        # An exit direction can only lead to one room.
+        nav_rr1 :: north_of(r, r') & north_of(r'', r') -> fail();
+        nav_rr2 :: south_of(r, r') & south_of(r'', r') -> fail();
+        nav_rr3 :: east_of(r, r') & east_of(r'', r') -> fail();
+        nav_rr4 :: west_of(r, r') & west_of(r'', r') -> fail();
+
+        # Two rooms can only be connected once with each other.
+        nav_rrA :: north_of(r, r') & south_of(r, r') -> fail();
+        nav_rrB :: north_of(r, r') & west_of(r, r') -> fail();
+        nav_rrC :: north_of(r, r') & east_of(r, r') -> fail();
+        nav_rrD :: south_of(r, r') & west_of(r, r') -> fail();
+        nav_rrE :: south_of(r, r') & east_of(r, r') -> fail();
+        nav_rrF :: west_of(r, r')  & east_of(r, r') -> fail();
+    }
+
+    inform7 {
+        type {
+            kind :: "room";
+        }
+
+        predicates {
+            at(P, r) :: "The player is in {r}";
+            at(t, r) :: "The {t} is in {r}";
+            free(r, r') :: "";  # No equivalent in Inform7.
+
+            north_of(r, r') :: "The {r} is mapped north of {r'}";
+            south_of(r, r') :: "The {r} is mapped south of {r'}";
+            east_of(r, r') :: "The {r} is mapped east of {r'}";
+            west_of(r, r') :: "The {r} is mapped west of {r'}";
+
+            north_of/d(r, d, r') :: "South of {r} and north of {r'} is a door called {d}";
+            south_of/d(r, d, r') :: "North of {r} and south of {r'} is a door called {d}";
+            east_of/d(r, d, r') :: "West of {r} and east of {r'} is a door called {d}";
+            west_of/d(r, d, r') :: "East of {r} and west of {r'} is a door called {d}";
+        }
+
+        commands {
+            go/north :: "go north" :: "going north";
+            go/south :: "go south" :: "going south";
+            go/east :: "go east" :: "going east";
+            go/west :: "go west" :: "going west";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/supporter.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/supporter.twl
@@ -1,0 +1,17 @@
+# supporter
+type s : t {
+    predicates {
+        on(o, s);
+    }
+
+    inform7 {
+        type {
+            kind :: "supporter";
+            definition :: "supporters are fixed in place.";
+        }
+
+        predicates {
+            on(o, s) :: "The {o} is on the {s}";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/logic/thing.twl
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/logic/thing.twl
@@ -1,0 +1,20 @@
+# thing
+type t {
+    rules {
+        examine/t :: at(P, r) & $at(t, r) -> at(P, r);
+    }
+
+    reverse_rules {
+        examine/t :: examine/t;
+    }
+
+    inform7 {
+        type {
+            kind :: "thing";
+        }
+
+        commands {
+            examine/t :: "examine {t}" :: "examining the {t}";
+        }
+    }
+}

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/text_grammars/house_instruction.twg
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/text_grammars/house_instruction.twg
@@ -1,0 +1,154 @@
+#-------------------------
+#Instructions Grammar
+#-------------------------
+obj_types:(o|k|f)
+obj_types_no_key:(o|f)
+on_types:(c|s)
+lock_types:(c|d)
+eat_types:(f)
+close_open_types:(d|c)
+lock_type_var:#lock_types#;#lock_types# #in_the_(r)#
+(s)_var:(s);(s) #in_the_(r)#
+(c)_var:(c);(c) #in_the_(r)#
+on_var:#on_types#;#on_types# #in_the_(r)#
+in_the_(r):in the (r);within the (r);inside the (r)
+make_syn_u:Make sure;Assure;Make it so;Doublecheck;Look and see;Make absolutely sure
+make_syn_v:make sure;assure;make it so;doublecheck;look and see;make absolutely sure
+by_the_syn:with the
+init_syn:in it;inside;placed inside
+into_syn:into;inside
+#actions
+##actions should start with a verb (ie:ensure, make sure, etc (these could probably just be a tag))
+look:look around in (r).
+examine:examine (o|k|f|d|c|s|t).
+inventory:examine your inventory.
+take:#take_synonym_1# the #obj_types# in the (r).;#take_synonym_1# the #obj_types# from the (r).;#take_synonym_1# the #obj_types# that's in the (r).
+take_synonym_1:take;retrieve;recover;pick up
+take/s:#take_synonym_1# the #obj_types# from the #on_var#.
+take/c:#take_synonym_1# the #obj_types# from the #on_var#.
+take:#pick-up_synonym_1# the #obj_types# from the floor of the (r).
+pick-up_synonym_1:pick-up;retrieve;recover;pick up;lift
+pick-up_synonym_v:Pick-up;Retrieve;Recover;Pick up;Lift
+insert:#insert_syn_1# the #obj_types# #into_syn# the #(c)_var#.;you can #insert_syn_1# the #obj_types# #into_syn# the #(c)_var#.
+insert_syn_u:Insert;Put;Place;Deposit
+insert_syn_1:insert;put;place;deposit
+insert_syn_v:inserted;put;placed;deposited
+begood:good;great;fantastic;a great idea
+put:#put_syn_v# the #obj_types# on the #(s)_var#.
+put_syn_u:Put;Place;Sit;Rest
+put_syn_v:put;place;sit;rest
+on_it_syn:on it;upon it
+drop:#drop_syn_v# the #obj_types# on the floor of the (r).
+drop_syn_u:Place
+drop_syn_v:place;drop;ditch;throw;toss;deposit
+eat:#eat_syn_1# the #eat_var#.
+eat_syn_u:Eat;
+eat_syn_1:eat;
+eat_syn_v:eaten;
+open:open the #lock_type_var#.;ensure that the #lock_type_var# is open.;#make_syn_v# that the #lock_type_var# is #open_syn#.
+open_syn:opened;open;wide open;ajar
+close:close the #lock_type_var#.;#make_syn_v# that the #lock_type_var# is #closed_syn#.
+closed_syn:closed;shut
+eat_var:#eat_types#;#eat_types#
+on_var:#on_types#;#on_types# #in_the_(r)#
+unlock:#unlock_key#;#unlock_no_key#
+unlock_key:unlock the #lock_type_var# #by_the_syn# (k).;check that the #lock_type_var# is unlocked #by_the_syn# (k).;#make_syn_v# that the #lock_type_var# is unlocked #by_the_syn# (k).;insert the (k) into the #lock_type_var#'s lock to unlock it.
+unlock_no_key:unlock the #lock_type_var#.;#make_syn_v# that the #lock_type_var# is unlocked.
+lock:#lock_key#;#lock_no_key#
+lock_key:lock the #lock_type_var# #by_the_syn# (k).;#make_syn_v# that the #lock_type_var# is locked #by_the_syn# (k).;#insert_syn_u# the (k) into the #lock_type_var# to lock it.
+lock_no_key:lock the #lock_type_var#.;#make_syn_v# the #lock_type_var# is locked.;#make_syn_v# that the #lock_type_var# is locked.
+go/north:#go_syn_l# north.;#tryto# #go_syn_l# north.
+go/south:#go_syn_l# south.;#tryto# #go_syn_l# south.
+go/east:#go_syn_l# east.;#tryto# #go_syn_l# east.
+go/west:#go_syn_l# west.;#tryto# #go_syn_l# west.
+go/north/d:#go_syn_l# through the north (d).;#tryto# #go_syn_l# through the north (d).
+go/south/d:#go_syn_l# through the south (d).;#tryto# #go_syn_l# through the south (d).
+go/east/d:#go_syn_l# through the east (d).;#tryto# #go_syn_l# through the east (d).
+go/west/d:#go_syn_l# through the west (d).;#tryto# #go_syn_l# through the west (d).
+go_syn_u:Go;Head;Venture;Travel;Move;Go to the;Take a trip
+go_syn_l:go;head;venture;travel;move;go to the;take a trip
+go_syn_v:visited;travelled;moved;ventured;gone
+tryto:try to;make an effort to;make an attempt to;attempt to
+wait:Wait.
+#action expandables
+#---------------
+
+
+#Compound Command Description Functions
+#----------------
+ig_unlock_open:open the locked #lock_types# using the (k).;unlock and open the #lock_types#.;unlock and open the #lock_types# using the (k).;open the #lock_types# using the (k).
+ig_unlock_open_take:open the locked #lock_types# using the (k) and take the #obj_types_no_key#.;unlock the #lock_types# and take the #obj_types_no_key#.;unlock the #lock_types# using the (k), and take the #obj_types_no_key#.;take the #obj_types_no_key# from within the locked #lock_types#.
+ig_open_take:take the #obj_types# from the (c).;open the (c) and take the #obj_types#.;from in the closed (c), take the #obj_types#.
+ig_take/c_unlock:take the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_take/s_unlock:take the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_take_unlock:#pick-up_synonym_1# the (k) and use it to unlock the #lock_types#.;unlock the #lock_types#, with the (k).;
+ig_open_insert:open the (c) and place the #obj_types# in it.;put the #obj_types# in the closed (c).;
+ig_insert_close:place the #obj_types# in the (c) and close it.;close (c) after placing the #obj_types# in it.
+ig_close_lock:close the #lock_types# and lock it.;close the #lock_types# and lock it with the (k).
+#Flavour Text
+#----------------
+quest:#prologue# (list_of_actions) #epilogue#
+quest_one_action:#prologue_one_action# (action)
+prologue:#welcome#! Here is your task for today. #newsentence#;#welcome#! Here is how to play! #newsentence#;#welcome#! #newsentence#;Hey, thanks for coming over to the TextWorld today, there is something I need you to do for me. #newsentence#
+prologue_one_action:#welcome#! Your task for today is to;#welcome#!;Your objective is to;Hey, thanks for coming over to TextWorld! Please
+newsentence:First off,;First of all,;First stop,;First step,;Your first objective is to;First thing I need you to do is to;First off, if it's not too much trouble, I need you to;First of all, you could, like,;First, it would be #begood# if you could
+action_separator: Then, ; Next, ; Following that, ; If you can #do# that, ; Once you #do# that, ; That done, ; With that over with, ; With that accomplished, ; With that done, ; Okay, and then, ; And then, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+epilogue:Once that's all handled, you can stop!;And once you've done that, you win!;And if you do that, you're the winner!;That's it!;Got that? Good!;Alright, thanks!
+do:manage;do;accomplish;get around to doing;finish;succeed at;get through with
+welcome:Welcome to TextWorld;You are now playing a #exciting# #game# of TextWorld;Welcome to another #exciting# #game# of TextWorld;It's time to explore the amazing world of TextWorld;Get ready to pick stuff up and put it in places, because you've just entered TextWorld;I hope you're ready to go into rooms and interact with objects, because you've just entered TextWorld;Who's got a virtual machine and is about to play through an #exciting# round of TextWorld? You do;
+exciting:exciting;fast paced;life changing;profound
+game:game;round;session;episode
+##Action separators
+##Need at least 5 for each action type
+action_separator_take: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_take/s: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_take/c: #afterhave# #havetaken# the #obj_types#, ; #after# #taking# the #obj_types#, ; With the #obj_types#, ; If you can get your hands on the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_eat: #afterhave# #ate# the #eat_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_insert: #afterhave# #inserted# the #obj_types# into the (c), ; #after# #inserting# the #obj_types# into the (c), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_put: #afterhave# #put_v# the #obj_types# on the (s), ; #after# #putting# the #obj_types# on the (s), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_open: #afterhave# #opened# the #close_open_types#, ; #after# #opening# the #close_open_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_unlock: #afterhave# #unlocked# the #lock_types#, ; #after# #unlocking# the #lock_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_lock: #afterhave# #locked# the #lock_types#, ; #after# #locking# the #lock_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go: #afterhave# #gone# (dir), ; #after# #getting# (dir), ; once you're (dir), ; once you're in the (dir), ; If you can manage to go (dir), ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/south: #afterhave# gone south, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/north: #afterhave# gone north, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/east: #afterhave# gone east, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_seperator_go/west: #afterhave# gone west, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_close: #afterhave# #closed# the #close_open_types#, ; #after# #closing# the #close_open_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+action_separator_drop: #afterhave# #dropped# the #obj_types#, ; #after# #dropping# the #obj_types#, ;#emptyinstruction1#;#emptyinstruction2#;#emptyinstruction3#;#emptyinstruction4#;#emptyinstruction5#;#emptyinstruction6#;#emptyinstruction7#;#emptyinstruction8#;#emptyinstruction9#;#emptyinstruction10#
+#Separator Symbols
+afterhave:After you have;Having;Once you have;If you have
+havetaken:taken;got;picked up
+havepicked-up:taken;got;picked up
+after:After;
+taking:taking;getting;picking up;stealing
+picking-up:taking;getting;picking up;stealing
+ate:ate;consumed
+inserted:inserted;put in
+inserting:inserting;putting in
+put_v:put;place;set;set down
+putting:putting;placing;setting;setting down
+opening:opening;pulling open
+opened:opened;pulled open
+unlocked:unlocked
+unlocking:unlocking
+locked:locked
+locking:locking
+gone:gone;gotten
+getting:going;getting
+closed:closed;shut
+closing:closing;shutting
+dropped:dropped;ditched;tossed;left behind
+dropping:dropping;leaving behind
+
+emptyinstruction1: And then, ;
+emptyinstruction2: Then, ;
+emptyinstruction3: After that, ;
+emptyinstruction4: And then, ;
+emptyinstruction5: After that, ;
+emptyinstruction6: Then, ;
+emptyinstruction7: And then, ;
+emptyinstruction8: After that, ;
+emptyinstruction9: And then, ;
+emptyinstruction10: Then, ;
+

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/text_grammars/house_obj.twg
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/text_grammars/house_obj.twg
@@ -1,0 +1,301 @@
+#-------------------------
+#Object Names Grammar
+#-------------------------
+#all-purpose expandables
+ordinary_adj:ordinary;normal;typical;standard;usual
+adj_stripped:#simpleadj#
+simpleadj:good;bad;small;big;heavy;light;great;terrible;expensive;cheap
+number:0;1;2;3;4;5;6;7;8;9
+#Room Type
+#-------------------
+#list each type of room with a ; between each
+room_type:clean;cook;rest;work;storage
+#Player
+# These values are typically empty
+(P):#(P)_adj# | #(P)_noun#
+(P)_noun:None
+(P)_adj:None
+#Rooms:
+# Each roomType must have specific rooms
+#-------------------
+#Creating a room: first, take the name of the roomtype as listed under #room_type# (which we'll call X for now). create three symbols with this: X_(r), X_(r)_noun, and X_(r)_adj. X_(r) will always be composed of X_(r)_adj | x_(r)_noun. If you want to subdivide a roomtype into two or more variants, you can add _type1, _type2, etc at then end of the noun and adj symbols. make sure that these changes are also accounted for in the X_(r) token, see below for examples
+
+(r):#(r)_adj# | #(r)_noun#
+(r)_noun:washroom;bathroom;cupboard;pantry;basement;closet;kitchen;kitchenette
+(r)_adj:nondescript;plain
+clean_(r):#clean_(r)_adj_type_1# | #clean_(r)_noun_type_1#;#clean_(r)_adj_type_2# | #clean_(r)_noun_type_2#;#clean_(r)_adj_type_3# | #clean_(r)_noun_type_3# ; #clean_(r)_adj_type_4# | #clean_(r)_noun_type_4#
+#Cleaning Self
+clean_(r)_noun_type_1:washroom;bathroom;restroom
+clean_(r)_adj_type_1:spotless;clean;cramped
+#Cleaning stuff
+clean_(r)_noun_type_2:launderette;laundromat;laundry place
+clean_(r)_adj_type_2:spotless;steamy;misty;crowded;cramped;cheap
+#Arguably a room inside a room?
+clean_(r)_noun_type_3:shower
+clean_(r)_adj_type_3:spotless;steamy;misty;marbled
+#Just Saunas
+clean_(r)_noun_type_4:sauna;steam room
+clean_(r)_adj_type_4:spotless;steamy;misty;luxurious;damp
+storage_(r):#storage_(r)_adj# | #storage_(r)_noun#
+storage_(r)_noun:pantry;basement;closet;attic;garage;vault;cellar;spare room
+storage_(r)_adj:spacious;roomy;cramped;stuffed;messy;forgotten;ugly;gloomy
+cook_(r):#cook_(r)_adj# | #cook_(r)_noun#
+cook_(r)_noun:kitchen;kitchenette;canteen;cookery;scullery;cookhouse;dish-pit
+cook_(r)_adj:#hot-adj# hot;steamy;hot;sweaty;balmy
+rest_(r):#rest_(r)_adj_type_1# | #rest_(r)_noun_type_1#;#rest_(r)_adj_type_2# | #rest_(r)_noun_type_2#
+#sleep
+rest_(r)_noun_type_1:bedroom;bedchamber;chamber
+rest_(r)_adj_type_1:cozy;relaxing;pleasant;sleepy
+#fun with friends
+rest_(r)_noun_type_2:lounge;bar;parlor;salon;playroom;recreation zone
+rest_(r)_adj_type_2:fun;entertaining;exciting;well lit
+work_(r):#work_(r)_adj# | #work_(r)_noun#
+work_(r)_noun:office;studio;workshop;cubicle;study
+work_(r)_adj:silent;austere;serious;still
+
+hot-adj:super;unreasonably;absurdly;alarmingly;upsettingly
+#Containers
+# Each roomType must has specific containers
+#container descriptions work like room descriptions, except the (r) is a (c)
+#-------------------
+(c):#(c)_adj_noun#
+(c)_noun:chest;box;safe;locker
+(c)_adj:sturdy;nice;ugly
+(c)_adj_noun:#(c)_adj# | #(c)_noun#
+clean_(c):#clean_(c)_adj_type_1# | #clean_(c)_noun_type_1#;#clean_(c)_adj_type_2# | #clean_(c)_noun_type_2#
+#Type 1
+clean_(c)_noun_type_1:cabinet;basket;box;safe;trunk;case
+clean_(c)_adj_type_1:gross;stained;spotless;plain;
+#Type 2
+clean_(c)_noun_type_2:drawer;dresser;cabinet
+clean_(c)_adj_type_2:#wood_type#wood
+
+storage_(c):#storage_(c)_adj# | #storage_(c)_noun#
+storage_(c)_noun:toolbox;chest;safe;locker;trunk;coffer;cabinet;crate;case;suitcase;display
+storage_(c)_adj:rusty;neglected;brand new
+
+cook_(c):#cook_(c)_adj# | #cook_(c)_noun#
+cook_(c)_noun:fridge;refrigerator;freezer;chest;cabinet;case
+cook_(c)_adj:fancy;big;small
+
+rest_(c):#rest_(c)_adj# | #rest_(c)_noun#
+rest_(c)_noun:dresser;chest;basket;box;safe;locker;trunk;coffer;suitcase;portmanteau
+rest_(c)_adj:new;dusty;clean;amazing
+
+work_(c):#work_(c)_adj# | #work_(c)_noun#
+work_(c)_noun:cabinet;box;safe;locker;trunk;bureau;coffer;case;suitcase;toolbox;portmanteau;display
+work_(c)_adj:iron;rusty;ancient
+
+
+
+fruit:watermelon;melon;honeydew;strawberry;apple;pear;grape;kiwi;cantaloupe
+#Doors
+# Each roomType must has specific doors
+#-------------------
+#Etc Etc, but the (r) is now a (d), and you shouldn't create room specific types
+(d):#(d)_adj# | #(d)_noun#
+(d)_adj:#wood_type#;wooden;stone
+madeof:made of
+wood_type:oak;birch;maple;balsam;beech;mahogany;walnut;cedar;pine;
+(d)_noun:door;portal;gate;passageway;gateway;hatch
+#Supporters
+# Each roomType must has specific supporters
+#-------------------
+#Like containers, but with a (s)
+(s):#(s)_adj# | #(s)_noun#
+(s)_noun:shelf;table;pedestal;slab
+(s)_adj:#(o)_adj#
+clean_(s):#clean_(s)_adj# | #clean_(s)_noun#
+clean_(s)_noun:board;shelf;table;counter;rack;bench
+clean_(s)_adj:dusty;chipped;shiny
+storage_(s):#storage_(s)_adj# | #storage_(s)_noun#
+storage_(s)_noun:shelf;table;workbench;counter;rack;stand
+storage_(s)_adj:rusty;shoddy;splintery;rough
+cook_(s):#cook_(s)_adj# | #cook_(s)_noun#
+cook_(s)_noun:counter;board;shelf;table;rack;chair;plate;bowl;pan;platter;saucepan
+cook_(s)_adj:greasy;soaped down;filthy;messy
+rest_(s):#rest_(s)_adj# | #rest_(s)_noun#
+rest_(s)_noun:bed;couch;shelf;bookshelf;desk;bed stand;mantelpiece;mantle;bar;bench;stand;recliner
+rest_(s)_adj:comfy;warm;worn-out
+work_(s):#work_(s)_adj# | #work_(s)_noun#
+work_(s)_noun:stand;bookshelf;table;chair;shelf;desk;mantelpiece;mantle;stand;armchair
+work_(s)_adj:stern;solid;worn;gross
+
+# Objects
+# Each roomType must have specific objects
+#-------------------
+#(s) --> (o) Very useful to create multiple subtypes to avoid inappropriate or awkward adjective pairing
+(o):#(o)_adj# | #(o)_noun#
+(o)_noun:pencil;pen
+(o)_adj:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;simple;hefty;modest;austere
+#clean objects
+clean_(o):#clean_(o)_adj_type_1# | #clean_(o)_noun_type_1#;#clean_(o)_adj_type_2# | #clean_(o)_noun_type_2#;#clean_(o)_adj_type_3# | #clean_(o)_noun_type_3#;#bugobject#
+clean_(o)_noun:#clean_(o)_noun_type_1#;#clean_(o)_noun_type_2#;#clean_(o)_noun_type_3#
+clean_(o)_adj:#clean_(o)_adj_type_1#;#clean_(o)_adj_type_2#;#clean_(o)_adj_type_3#
+clean_(o)_adj_noun:#clean_(o)_adj_type_1# | #clean_(o)_noun_type_1#;#clean_(o)_adj_type_2# | #clean_(o)_noun_type_2#;#clean_(o)_adj_type_3# | #clean_(o)_noun_type_3#
+#appliances
+clean_(o)_noun_type_1:iron;mop;broom;vacuum
+clean_(o)_adj_type_1:new;old;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;decorated;austere
+#paperproducts
+clean_(o)_noun_type_2:paper towel;sponge
+clean_(o)_adj_type_2:new;old;used;dusty;torn;ripped;dirty;clean;large;small;fancy;plain;ornate;elegant;immaculate;simple;hefty;modest;decorated;austere;embroidered
+#non-disposable
+clean_(o)_noun_type_3:mat;towel;soap dispenser;mop;broom;shirt;sock;sponge
+clean_(o)_adj_type_3:new;old;used;dusty;clean;large;small;fancy;plain;dirty;elegant;tacky
+#storage objects
+storage_(o):#storage_(o)_adj_type_1# | #storage_(o)_noun_type_1#;#storage_(o)_adj_type_2# | #storage_(o)_noun_type_2#;#storage_(o)_adj_type_4# | #storage_(o)_noun_type_4#
+storage_(o)_noun:#storage_(o)_noun_type_1#;#storage_(o)_noun_type_2#;#storage_(o)_noun_type_4#
+storage_(o)_adj:#storage_(o)_adj_type_1#;#storage_(o)_adj_type_2#;#storage_(o)_adj_type_4#
+#clothing
+storage_(o)_noun_type_1:shirt;sock;shoe;glove;hat;scarf;cloak;top hat;pair of pants
+storage_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;contemporary;modern;dirty;elegant;immaculate;simple;modest;gaudy;fashionable;tacky
+#appliances
+storage_(o)_noun_type_2:lightbulb;broom;cane;pair of headphones;lampshade;frisbee;golf #golf#
+storage_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;modern;dirty;elegant;immaculate;simple;hefty;modest;off brand;useless;broken
+golf:club;tee;ball;
+#bugs
+bugobject:#storage_(o)_adj_type_4# | #storage_(o)_noun_type_4#
+storage_(o)_adj_type_4:wriggling;grotesque;repulsive;tiny
+storage_(o)_noun_type_4:worm;fly larva;bug;insect;nest of #bugs#;butterfly;shadfly
+bugs:bugs;insects;spiders;earwigs;beetles;grubs;ticks;kittens;puppies;shrimp;caterpillars;bats;toads;bunnies
+#cook objects
+cook_(o):#cook_(o)_adj_type_1# | #cook_(o)_noun_type_1#;#cook_(o)_adj_type_2# | #cook_(o)_noun_type_2#;#cook_(o)_adj_type_3# | #cook_(o)_noun_type_3#;#bugobject#
+#cook_(o)_adj_type_4# | #cook_(o)_noun_type_4#
+cook_(o)_noun:#cook_(o)_noun_type_1#;#cook_(o)_noun_type_2#;#cook_(o)_noun_type_3#
+#cook_(o)_noun_type_4#
+cook_(o)_adj:#cook_(o)_adj_type_1#;#cook_(o)_adj_type_2#;#cook_(o)_adj_type_3#
+#cook_(o)_adj_type_4#
+#utensil
+cook_(o)_noun_type_1:fork;knife;spoon;spork;teaspoon
+cook_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere;plastic
+#cooking appliance
+cook_(o)_noun_type_2:napkin;whisk;ladle;blender;kettle;teapot
+cook_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere;fancy;broken
+#vessel/plate
+cook_(o)_noun_type_3:mug;bowl;teacup;glass;coffee cup
+cook_(o)_adj_type_3:new;old;used;clean;large;small;fancy;plain;ornate;antique;contemporary;modern;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;chipped
+#rest objects
+rest_(o):#rest_(o)_adj_type_1# | #rest_(o)_noun_type_1#;#rest_(o)_adj_type_2# | #rest_(o)_noun_type_2#;#rest_(o)_adj_type_3# | #rest_(o)_noun_type_3#;#rest_(o)_adj_type_5# | #rest_(o)_noun_type_5#;#bugobject#
+rest_(o)_noun:#rest_(o)_noun_type_1#;#rest_(o)_noun_type_2#;#rest_(o)_noun_type_3#;#rest_(o)_noun_type_5#
+rest_(o)_adj:#rest_(o)_adj_type_1#;#rest_(o)_adj_type_2#;#rest_(o)_adj_type_3#;#rest_(o)_adj_type_5#
+#screen
+rest_(o)_noun_type_1:tv;laptop;tablet;monitor
+rest_(o)_adj_type_1:shiny;widescreen;shut off;flat-screen
+#electronic
+rest_(o)_noun_type_2:tv;controller;dvd;cd;lamp;laptop;synthesizer
+rest_(o)_adj_type_2:new;old;used;dusty;clean;large;small;fancy;plain;fancy
+#comfortable things
+rest_(o)_noun_type_3:pillow;blanket;plant;cushion
+rest_(o)_adj_type_3:cozy;comfy;comfortable;plush;frilly;nice;small;big;heavy;cute
+#weird book
+rest_(o)_adj_type_5:cool;gigantic;enormous;famous;old
+rest_(o)_noun_type_5:novel;book;manuscript;poem;textbook
+#work objects
+work_(o):#work_(o)_adj_type_1# | #work_(o)_noun_type_1#;#work_(o)_adj_type_2# | #work_(o)_noun_type_2#;#work_(o)_adj_type_3# | #work_(o)_noun_type_3#;#work_(o)_adj_type_4# | #work_(o)_noun_type_4#;#bugobject#
+work_(o)_noun:#work_(o)_noun_type_1#;#work_(o)_noun_type_2#;#work_(o)_noun_type_3#;#work_(o)_noun_type_4#
+work_(o)_adj:#work_(o)_adj_type_1#;#work_(o)_adj_type_2#;#work_(o)_adj_type_3#;#work_(o)_adj_type_4#
+#utensil
+work_(o)_noun_type_1:pen;pencil;staple;mug;disk;cd;book;backup calendar
+work_(o)_adj_type_1:new;old;used;dusty;clean;large;small;fancy;plain;ornate;dirty;elegant;immaculate;simple;hefty;modest;gaudy;decorated;austere
+#electronic
+work_(o)_noun_type_2:printer;mouse;keyboard;laptop;desktop computer;telephone
+work_(o)_adj_type_2:fancy;broken;operational;working
+#calendar
+work_(o)_noun_type_3:Cat Calendar;Comic Strip Calendar;Quote of the Day Calendar;Advent Calendar
+work_(o)_adj_type_3:heartwarming;hilarious;mind-expanding;out of date;typo-riddled
+#device for using another device
+work_(o)_noun_type_4:stapler;printer;mouse;keyboard;folder;binder
+work_(o)_adj_type_4:operational;broken;expensive;useless;outmoded
+
+
+
+
+# Food
+# Each roomType must have specific food
+#-------------------
+#The below should work as an expandable food pyramid. This can be made room specific.
+
+#Base food
+(f):#(f)_adj# | #(f)_noun#
+(f)_adj:#(f)_adj_good#;#(f)_adj_bad#;#(f)_adj_neutral#
+(f)_noun:#(f)_noun_fruit#;#(f)_noun_vegetable#;#(f)_noun_grain#;#(f)_noun_protein#;#(f)_noun_dairy#;#candy#
+(f)_noun_fruit:#fruit#;apple;banana;grape;coconut;pear;durian;#candy#;#berry#berry;berry
+(f)_noun_vegetable:broccoli;carrot;cucumber;onion;garlic clove;potato;cabbage;cauliflower;pizza;salad
+(f)_noun_grain:loaf of bread;sandwich
+(f)_noun_protein:;legume;cashew;peanut;burger
+(f)_noun_dairy:stick of butter;fondue
+(f)_adj_good:fresh;maturing;soft;chilled;organic
+(f)_adj_bad:aging;half-eaten;rotting
+(f)_adj_neutral:frozen;large;small;massive;tiny;hefty;sizable;dried;dry;pureed
+berry:straw;blue;rasp;black;elder;boysen;lingon;huckle;logan;cran;goji;goose
+
+#Clean food
+#----------
+
+clean_(f):#(f)#
+
+#Storage food
+#------------
+
+storage_(f):#(f)#
+
+#Cook food
+#---------
+
+cook_(f):#(f)#
+
+#Rest food
+#---------
+
+rest_(f):#(f)#
+
+#Work food
+#---------
+
+work_(f):#(f)#
+
+
+candy:chocolate bar;gummy bear;candy bar;licorice strip;cookie
+# Key
+# Each roomType must have specific keys
+#-------------------
+(k):#(k)_adj# | #(k)_noun#
+(k)_adj:iron;brass;metal;rusty;steel;iron;aluminum;copper
+(k)_noun:key;keycard;latchkey;passkey
+#Object Descriptor Functions
+#---------------------------
+(P)_desc:It's you.
+(c)_desc:The (name) looks strong, and impossible to #force_open#.
+force_open:break;crack;destroy
+(s)_desc:The (name) is #supp_stable#.
+supp_stable:stable;wobbly;unstable;balanced;durable;reliable;solid;undependable;solidly built;an unstable piece of #garbage#;shaky
+garbage:garbage;trash;junk
+(o)_desc:The (name) is #obj_what#.;The (name) #looks_seems# #out_in_place# here
+obj_what:unremarkable;clean;dirty;modern;antiquated;well-used;brand new;expensive looking;cheap looking
+looks_seems:looks;seems;appears;appears to be;would seem to be
+out_in_place:out of place;to fit in;well matched to everything else
+restaurant:Burger#place#
+place:town;village;hamlet;burg;ville;City
+(f)_desc:The (name) looks #food_what#.;that's a (name-adj) (name-n)!;You couldn't pay me to eat that (name-adj) thing.
+food_what:appetizing;delicious;tasty;appealing;delectable;heavenly;inviting;savory;tantalizing;tempting
+(k)_desc:The (name) is cold to the touch;The (name) is #key_weight#.;The metal of the (name) is #key_metal#.;The (name) looks useful
+key_weight:heavy;light;weighty;surprisingly heavy;heavier than it looks
+key_metal:antiqued;brushed;hammered;polished;satin;rusty
+(d)_desc:The (name) looks #door_what_is#.;it's a #door_what_is# (name-n);it is what it is, a (name)
+door_what_is:imposing;sturdy;well-built;durable;robust;rugged;hefty;commanding;grand;noble;ominous;towering;manageable;solid;stuffy
+#State descriptors
+#-----------------
+openable_desc:[if open]It is open.[else if closed]It is closed.[otherwise]It is locked.[end if];[if open]You can see inside it.[else if closed]You can't see inside it because the lid's in your way.[otherwise]There is a lock on it.[end if]
+on_desc:On the (name), is [a list of things on the (obj)].;You can see [list of things on the (obj)] on the (name);this (name) has the following upon it, [list of things on the (obj)];you gaze in terror at the [list of things on the (obj)] that lie upon this very (name)!; "now why" you think, "am I looking at [list of things on the (obj)] on this (name)?"
+#Key Match Adjectives
+#These adjectives CANNOT be used elsewhere!
+#----------------
+letter:A;B;C;D;E;F;G;H;I;J;K;L;M;N;O;P;Q;R;S;T;U;V;W;X;Y;Z
+clearancelevel:type #number#;type #letter#;#brand#;#brand#;#brand#;#shape#;#shape#;#shape#;#smell# scented;
+brand:#brandname# style;#brandname# limited edition;#brandname#
+brandname:Microsoft;American;Canadian;Henderson's;TextWorld
+shape:rectangular;cuboid;spherical;formless;non-euclidean
+colour:red;blue;chartreuse;purple;violet;orange;yellow;green;brown;teal;cyan
+smell:vanilla;lavender;cake;fudge;fresh laundry;soap
+(k<->d)_match:#(k)_adj# | #clearancelevel# #(k)_noun# <-> #(d)_adj# | #clearancelevel# #(d)_noun#; #colour# | #(k)_noun# <-> #colour# | #(d)_noun#
+(k<->c)_match:#(k)_adj# | #clearancelevel# #(k)_noun# <-> #(c)_adj# | #clearancelevel# #(c)_noun#; #colour# | #(k)_noun# <-> #colour# | #(c)_noun#

--- a/textworld/challenges/tw_treasure_hunter/textworld_data/text_grammars/house_room.twg
+++ b/textworld/challenges/tw_treasure_hunter/textworld_data/text_grammars/house_room.twg
@@ -1,0 +1,451 @@
+#-------------------------
+#Room Descriptor Grammar
+#-------------------------
+
+# Inform7 snippets
+#-----------------
+#Shouldn't need to be messed with. These are shortcuts for when you need to use i7 code. Probably a bad idea to include symbols or tokens inside these
+i7_closed/open:[if (obj) is open]an open[otherwise]a closed[end if]
+i7_list_in:[a list of things in the (obj)]
+i7_list_on:[a list of things on the (obj)]
+i7_empty:[if (obj) contains nothing]an empty[otherwise]a[end if]
+inform7:[if (obj) is locked]a locked[else if (obj) is open]an open[otherwise]a closed[end if]
+inform7A:[if (obj) is locked]A locked[else if (obj) is open]An open[otherwise]A closed[end if]
+inform7noa:[if (obj) is locked]a locked[else if (obj) is open]an open[otherwise]a closed[end if]
+inform7noun:[if (obj) is locked]locked[else if (obj) is open]open[otherwise]closed[end if]
+inform7nounnoa:[if (obj) is locked]locked[else if (obj) is open]open[otherwise]closed[end if]
+
+#Room Intro#
+#----------
+#Text for introducing the room. ex: "Greetings, you are now in the hot kitchen"
+# dec:[if unvisited]#GREETING!# #dec_type##suffix_(r)#[otherwise]#revisit#[end if];[if unvisited]#dec_type##suffix_(r)#[otherwise]#revisit#[end if]
+dec:#dec_type##suffix_(r)#
+
+### First time in room ###
+dec_type:#reg-0#;#normal-0#;#difficult-0#;#moredifficult-0#;#playful-0#
+reg-0:#04#;#05#;#06#
+normal-0:#07#
+difficult-0:#016#
+moredifficult-0:#017#
+playful-0:#01#;#02#;#03#;#08#;#09#;#010#;#011#;#012#;#013#;#014#;#015#;#018#;#019#;#020#;#021#;#022#;#023#;#024#;#025#;#026#;#027#;#028#
+
+### Revisiting room ###
+revisit:You have re-entered the (name).;You re-enter the (name). You're so confused, you need to be reminded what is in the room, even though you were just here seconds ago.;What, you thought if you went somewhere and came back this place would stop being the (name)?;Ah, the (name). You have lots of great memories of this place. Fresh memories. You were just here a second ago.;Well here you are, back in the (name).;Just when you thought you'd never have to see the (name) again, you walk right back into it.;Welcome back to the (name).
+
+#Room Intro Templates
+#-------------------
+
+01:I am sorry to announce that you are now in the (name)
+02:Ah, the (name-n). This is some kind of (name-n), really great (name-adj) vibes in this place, a wonderful (name-adj) atmosphere. And now, well, you're in it
+03:Okay, so you're in a (name-n), cool, but is it (name-adj)? You better believe it is
+04:#dec_find-yourself# in a (name);#dec_guess-what# (name)
+05:Well, here we are in #dec_a_the# (name)
+06:You're now in #dec_a_the# (name)
+07:You've entered a (name);You've just #dec_walked_into# a (name)
+08:This might come as a shock to you, but you've just #dec_entered# a (name)
+09:I am #announce_mood# to announce that you are now in the (name)
+010:Ah, the (name-n). This is some kind of (name-n), really great (name-adj) vibes in this place, a wonderful (name-adj) atmosphere
+011:You have #dec_entered# the most (name-adj) of all possible (name-n)s
+012:Of every (name-n) you could have #dec_walked_into#, you had to #dec_walk_into# a (name-adj) one
+013:You have #dec_entered# a (name-n). Not the (name-n) you'd expect. No, this is a (name)
+014:You are in a (name-n). It seems to be pretty (name-adj) here
+015:You #dec_what# in a (name-adj) kind of place. That is to say, you're in a (name-n)
+016:#dec_find-yourself# in a (name-n). A (name-adj) one
+017:#dec_find-yourself# in a (name-n). A (name-adj) kind of place
+018:#017#
+019:You've #dec_entered# a (name-adj) room. Your mind races to think of what kind of room would be (name-adj). And then it hits you. Of course. You're in the (name)
+020:If you're wondering why everything seems so (name-adj) all of a sudden, it's because you've just #dec_walked_into# the (name)
+021:Fancy seeing you here. Here, by the way, being the (name);I never took you for the sort of person who would show up in a (name), but I guess I was wrong
+022:This is going to sound unbelievable, but you've just entered a (name);You're not going to believe this, but you've just entered a (name)
+023:You make a grand eccentric entrance into a (name);You make another one of your grand eccentric entrances into a (name)
+024:Look at you, bigshot, walking into a (name) like it isn't some huge deal
+025:Look around you. Take it all in. It's not every day someone gets to be in a (name)
+026:You've seen better (name-n)s, but at least this one seems pretty (name-adj);I just think it's awesome that you're in a (name) now;I just think it's great that you've just entered a (name)
+027:A #signquality# #sign# tells you that you are now in the (name);Look at that #sign#! What does it say? It says Welcome to the (name)? Well that's cool
+028:This just in- You, in the (name);Welcome to the (name);Wow! You're in a (name);Here we are in the (name);You've entered a (name);This (name-n) you have just entered is definitely (name-adj)
+#Expandables for Room Symbols
+#----------
+
+GREETING!:GREETING!;GREETINGS!;HELLO!;ALRIGHT THEN!
+dec_entered:entered;walked into;fallen into;moved into;stumbled into;come into
+dec_find-yourself:You #dec_what#
+dec_guess-what:#dec_well-guess#, you are in #dec_a_the# place we're calling #dec_a_the#
+dec_well-guess:Guess what;Well how about that;Well I'll be
+dec_what:are;find yourself;arrive
+dec_a_the:a;the
+dec_in_at:in;at
+dec_walk_into:walk into;show up in;saunter into;come round
+dec_walked_into:walked into;shown up in;sauntered into
+announce_mood:sorry;pleased;excited;stoked;so happy;honoured;required;obligated
+signquality:decrepit;rusty;laminated;crooked;well framed
+sign:sign;placard;notice;signboard;board
+#Description Separators
+#-------
+#Used to separate the description of different object types
+
+#First
+#first:First, you look for (next object type);First, you scan the room for (next object type);You first scan the room for (next object type)
+#Middle
+#middle:After that, you look for (next object type);Once you've ascertained the amount of (previous object type), you start looking for (next object type);
+#Last
+#last:and lastly, you check for (next object type)
+
+#Container Descriptions
+#----------------------
+#Rules for Container Descriptions
+#Good idea to subdivide these into difficulty levels
+#room_desc_(c): generates all container descriptions
+#containerdescription: contains all physical exterior descriptions of containers
+#room_desc_(c)_1_name: describes the container as an adj+noun
+#room_dec_(c)_1_noun: describes the container as a noun
+#room_desc_(c)_content: decides if we append a description of the container's contents depending on if the container is open or closed
+#opencontainer:what is appended if the container is open
+#room_desc_(c)_2_adj: adds an adjective and a list of contents (creates doubled adjectives?)
+#room_desc_(c)_2: list of contents without an adjective
+
+room_desc_(c):#containerdescription##room_desc_(c)_content#
+#special_container#.
+containerdescription:#room_desc_(c)_1_name#;#room_desc_(c)_1_noun#
+room_desc_(c)_content:[if (obj) is open and there is something in the (obj)] #opencontainer##suffix#[end if][if (obj) is open and the (obj) contains nothing] #emptyreaction#[end if]
+opencontainer:The (name) contains #i7_list_in#
+#room_desc_(c)_2_adj#;#room_desc_(c)_2#
+emptyreaction:The (name-n) is empty, what a horrible day!;The (name-n) is empty! What a waste of a day!;The (name-n) is empty! This is the worst thing that could possibly happen, ever!;Empty! What kind of nightmare TextWorld is this?;What a letdown! The (name-n) is empty!
+room_desc_(c)_1_name:#reg-a#;#normal-a#;#difficult-a#;#moredifficult-a#;#playful-a#
+
+reg-a:#a1#;#a2#
+normal-a:#a3#;#a4#;#a5#
+difficult-a:#a6#
+moredifficult-a:#reg-a#
+playful-a:#reg-a#
+
+room_desc_(c)_1_noun:#reg-b#;#normal-b#;#difficult-b#;#moredifficult-b#;#playful-b#
+
+reg-b:#b1#;#b2#
+normal-b:#b3#;#b4#;#b5#
+difficult-b:#reg-b#
+moredifficult-b:#reg-b#
+playful-b:#reg-b#
+
+room_desc_(c)_2_adj:#c1#;#c2#;#c3#;#c4#;#c5#;#c6#;#c7#;#c8#;#c9#
+
+room_desc_(c)_2:#d0#;#d1#;#d2#;#d3#;#d4#
+
+room_desc_(c)_multi_noun:#e1#
+room_desc_(c)_multi_open_noun:#f1#;#f2#;#f3#;#f4#;#f5#;#f6#
+
+room_desc_(c)_multi_adj:#g1#
+room_desc_(c)_multi_open_adj:#h1#;#h2#;#h3#;#h4#
+
+
+
+#Container Description Templates
+#-----------------------------
+
+# A #
+
+a1:#how_see# #inform7# (name).;#a6#
+a2:#how_see# #inform7# #name_var# #here_alt#.;#a6#
+a3:#inform7A# #name_var# is #here_alt#.;#a6#
+a4:#a1#;#a6#
+a5:#a2#;#a6#
+a6:#prefix# (name)#suffix#
+
+# B #
+
+b1:#how_see# #inform7# (name-n).;#b5#
+b2:#how_see# #inform7# (name-n) #here_alt#.;#b5#
+b3:#inform7A# (name-n) is #here_alt#.;#b5#
+b4:#b1#;#b5#
+b5:#prefix# (name-n)#suffix#
+
+# C #
+
+c1:#it_is# (name-adj), and #contains# #i7_list_in#.
+c2:#it_is# (name-adj). Also, there #listwithis# in it.
+c3:#c1#
+c4:#ContentsC-# [list of things in the (obj)].
+c5:there [is|are] [a list of things in the (obj)] in this silly (name-adj) thing.
+c6:#c9#
+c7:#c9#
+c8:Let's see what's inside - #i7_list_in#.
+c9:#it# #reminds_you# the containers #ofyouryouth#. Oh, how they also contained #i7_list_in#.
+
+# D #
+d0:the (name) contains #i7_list_in#.
+d1:It #contains# #i7_list_in#.;There is #i7_list_in# in it.
+d2:There #listwithis# #foundin# it.
+d3:You can see #i7_list_in# in the (name-n).
+d4:In it, you can see #i7_list_in#.
+
+# E #
+
+e1:[if (obj) is open]#room_desc_(c)_multi_open_noun#.[else if (obj) is locked]The (name-n) is locked.[otherwise]The (name-n) is closed.[end if]
+
+# F #
+
+f1:The (name-n) #contains# #i7_list_in#
+f2:There #listwithis# #foundin# the (name-n)
+f3:You can see #i7_list_in# in the (name-n)
+f4:#f5#;#f6#
+f5:#f6#
+f6:The (name-n) #reminds_you# the containers #ofyouryouth#. Oh, how they also contained #i7_list_in#
+
+# G #
+
+g1:[if (obj) is open]#room_desc_(c)_multi_open_adj#.[else if (obj) is locked]The (name-adj) one is locked.[otherwise]The (name-adj) one is closed.[end if]
+
+# H #
+
+h1:The (name-adj) one #contains# #i7_list_in#
+h2:There #i7_list_in# #foundin# the (name-adj) one
+h3:You can see #i7_list_in# in the (name)
+h4:In the (name-adj) one, you can see #i7_list_in#
+
+#Expandables for Container Symbols
+#---------------------------------
+
+it:It;Something about it
+reminds_you:reminds you of;looks like;floods your mind with memories of;is reminiscent of;is just like
+ofyouryouth:of your youth;that you knew in your youth;that you knew so long ago;that you knew so long ago, in your youth
+contains:contains;has;is filled with;reveals inside it;holds;shelters;offers you;reveals to you
+foundin:in;found in
+it_is:It is;You can see that it is;Upon examination, you see that it is
+name_var:(name);(name-n), which looks (name-adj),;(name-adj) looking (name-n)
+contained:contained;held;had;had in it;revealed;concealed;sheltered;offered you;revealed to you;guarded;protected
+inform7:[if (obj) is locked]a locked[else if (obj) is open]an opened[otherwise]a closed[end if]
+inform7noa:[if (obj) is locked]a locked[else if (obj) is open]an opened[otherwise]a closed[end if]
+inform7noun:[if (obj) is locked]locked[else if (obj) is open]opened[otherwise]closed[end if]
+inform7nounnoa:[if (obj) is locked]locked[else if (obj) is open]opened[otherwise]closed[end if]
+listwithis: [is-are a list of things in the (obj)]
+lookthere:Look over there;Wow! look at that
+ContentsC-:Contents-;Contained within-;Inside are the following-;Inventory is as follows-;Here's what's inside
+
+#Supporter Descriptions
+#----------------------
+#Similar to Container descriptions, but without open/close or lock/unlock
+#room_desc_(s): hub
+#room_desc_(s)_1_noun : description of supporter without adjective. Paired with--> room_desc_(s)_2_adj
+#room_desc_(s)_1_name : same as above, but with an adjective
+#room_desc_(s)_2_adj : adjective for supporter plus a list of things on it
+#room_desc_(s)_2:
+
+room_desc_(s):#room_desc_(s)_1_noun# #room_desc_(s)_2_adj#;#room_desc_(s)_1_name# #room_desc_(s)_2#
+
+room_desc_(s)_1_noun:#prefix# (name-n)#suffix_(s)_mid#
+
+room_desc_(s)_1_name:#prefix# (name)#suffix_(s)_mid#
+
+room_desc_(s)_2_adj:The (name-n) is (name-adj).[if there is something on the (obj)] On the (name) #how_see_u# #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)] #emptysupporter##suffix_(s)_end_angry#[end if]
+#;The (name-n) is (name-adj) [if name has something on it] on the (name) #i7_list_on#[else if the (name) is empty]#emptysupporter#[end if]
+
+room_desc_(s)_2:[if there is something on the (obj)]On the (name) #how_see_u# #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter##suffix_(s)_end_angry#[end if];[if there is something on the (obj)]You see #i7_list_on# on the (name-n)#suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter##suffix_(s)_end_angry#[end if]
+#[if name has something on it] on the (name) #i7_list_on#[else if the (name) is empty]#emptysupporter#[end if]
+
+room_desc_(s)_multi_noun:[if there is something on the (obj)]On the (name-n), you see #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter_multi##suffix_(s)_end_angry#[end if]
+room_desc_(s)_multi_adj:[if there is something on the (obj)]On the (name-adj) one, you see #i7_list_on##suffix_(s)_end#[end if][if there is nothing on the (obj)]#emptysupporter_multi##suffix_(s)_end_angry#[end if]
+emptysupporter:But there isn't a thing on it;Unfortunately, there isn't a thing on it;But the thing is empty;But the thing is empty, unfortunately;But the thing hasn't got anything on it;But oh no! there's nothing on this piece of #trash#;The (name-n) appears to be empty;Looks like someone's already been here and taken everything off it, though;However, the (name-n), like an empty (name-n), has nothing on it;
+emptysupporter_multi:There isn't a thing on the (name-n);The (name-n) is empty;Look at the (name-n). There's nothing on this piece of #trash#;But the (name-n) hasn't got anything on it;What a letdown, there's nothing here;
+#Supporter Description Templates
+#-------------------------------
+
+
+
+#Expandables for Supporter Symbols
+#--------------------------------
+
+on_it:on it;lying on it;resting on it;upon it
+ContentsS-:Contents-;Upon it are displayed the following-;Upon it you may see the following-;Upon it lie the following-;Upon the (name-n) are displayed the following-;Upon the (name-n) you may see the following-;Upon the (name-n) lie the following-
+held:held;carried;had;presented;held up;was used to support
+trash:trash;garbage;junk
+#Group Descriptions
+#------------------
+room_desc_group:You can see (^) (val), (name), here#suffix-multi#;Your attention is drawn to (^) (val), (name)#suffix-multi#
+
+#Expandables for Group Description Symbols
+#--------------------------------
+
+this_the:this;the
+room:room;place;part of the game;zone;chamber;area;sector
+
+#Exit Descriptions
+#----------------
+
+#room_desc_(d): describes a single door in the room
+#room_desc_(dir): describes a single unblocked exit in the room
+#room_exit_desc: describes multiple unlocked exits in the room
+#room_desc_exits: possible unnecessary
+#room_desc_doors_closed: describes a group of closed doors in the room
+#room_desc_doors_open: describes a group of open doors in the room
+
+room_desc_(d):There is #i7_closed/open# (name) leading (dir).
+room_desc_(dir):There is an #unblocked# exit to the (dir).;There is an exit to the (dir). Don't worry, it is #unblocked#.;You need an #unblocked# exit? You should try going (dir).;You don't like doors? Why not try going (dir), that entranceway is #unblocked#.
+room_exit_desc:#easy1#.;#medium1#.;#hard1#.
+room_desc_exits:There [is an|are] #unblocked# [exit|exits] to the (dir).
+room_desc_doors_closed:#easy0a#.
+room_desc_doors_open:#easy0b#.
+#[if (name) is open]#room_desc_doors_open#[else if (name) is closed]#room_desc_doors_open#[end if]
+#room_(d)_exit_desc_alt:[If (name) is open]#easy2#[else if (name) closed] closed [end if];[If (name) is open]#medium2#[else if (name) is closed] closed [end if];[If (name) is open]#hard2#[else if (name) is closed] closed [end if]
+#room_(d)_exit_desc:[if (name) is open]#easy3#[else if (name) is closed] closed [end if];[If (name) is open]#medium3#[else if (name) is closed] closed [end if];[If (name) is open]#hard3#[else if (name) is closed]closed[end if]
+
+#Templates for Exit Descriptions
+
+# 0a #
+
+easy0a:There are (^) closed doors, (name-indefinite), here;Let's see how many closed doors there are. Looks like (^), (name-indefinite);There are (^) closed doors here, (name-indefinite);
+
+# 0b #
+
+easy0b:There are (^) open doors, (name-indefinite), here;Let's see how many open doors there are. Looks like (^), (name-indefinite)
+
+# 1 #
+
+easy1:There [is an|are] #unblocked# [exit|exits] to the (dir);There [is an|are] [exit|exits] to the (dir). And hey, don't worry, [they are|it's] #unblocked#
+medium1:[An exit|Exits] #unblocked# [lies|lie] to the (dir);You can go (dir) from here without having to deal with any doors
+hard1:it looks like you can exit to the (dir), if doors aren't really your #yourthing#;if you want to leave, and doors really aren't your #yourthing# you could try going (dir);If you're not really a door person, you could leave by the (dir);If you're not really a doors fan, you could leave by the (dir);not a fan of the doors? Why not go (dir);Hot tip- if you go (dir), you won't have to deal with any doors
+
+
+# 2 #
+
+easy2:#easy21#;#easy22#
+easy21:There [is a door|are doors], #looks# (name-adj), leading (dir);a (name) leads (dir)
+easy22:There is (name-indefinite) leading (dir)
+medium2:You #canshould# see [the door|a door] [at the|blocking the] (dir) [exit|exits]
+hard2:How do you get out? Well, there [is a door|are doors] to the (dir) of you
+
+# 3 #
+
+easy3:The [exit|exits] to the (dir) [is|are] going through (name)
+medium3:The (dir) [exit|exits] [has|have] (name-indefinite) blocking [it|them]
+hard3:The (dir) [exit|exits] [has|have] (name-n-indefinite) blocking [it|them]. the (name-n) [is|are] (name-adj)
+
+#Expandables for Exit Symbols
+#----------------------------
+yourthing:thing;bag;style;cup of tea
+door_what:leading;facing;heading
+unblocked:unblocked;unguarded
+
+#prefixes
+#-----------
+#To be affixed before object descriptions. Keep away from doors. Prefixes start with a uppercase letter and end with "a"
+prefix:You see a gleam over in a corner, where you can see a;What's that over there? It looks like it's a;You scan the room, seeing a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;You smell #smelltype# smell, and follow it to a;Were you looking for a (name-n)? Because look over there, it's a;You rest your hand against a wall, but you miss the wall and fall onto a;You scan the room for a (name-n), and you find a;You hear a noise behind you and spin around, but you can't see anything other than a;Look out! It's a- oh, never mind, it's just a;Look over there! a;Oh, great. Here's a;Hey, want to see a (name-n)? Look over there, a;If you haven't noticed it already, there seems to be something there by the wall, it's a;You bend down to tie your shoe. When you stand up, you notice a;Oh wow! Is that what I think it is? It is! It's a;You lean against the wall, inadvertently pressing a secret button. The wall opens up to reveal a;You see a;As if things weren't amazing enough already, you can even see a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a;#how_see# a
+prefix-multi:You see a gleam over in a corner, where you can see ;What's that over there? It looks like it's ;You scan the room, seeing ;#how_see# ;You bend down to tie your shoe. When you stand up, you notice ;You smell #smelltype# smell, and follow it to ;You can suddenly see ;
+prefix_(c):#prefix#
+prefix_(s):#prefix#
+
+#suffixes
+#-----------
+#To be affixed after object descriptions. Keep away from doors. Keep in mind a suffix is usually (but not always) followed by a prefix. Suffixes start with punctuation and end with a period (or exclamation/question mark).
+suffix_meta:. There's something about an object in a room that's just so... TextWorld.;. You can't really describe the (name-n) besides that it's (name-adj).;. Does this look like anything mentioned in the instructions?;. What a great pairing of adjectives and nouns!;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.;. Make a note of this, you might have to put stuff on or in it later on.
+suffix_fulfillment:. A (name-n)... Is that really what you were looking for?;. Is this it? Is this what you came to TextWorld to see? a (name-n)?;. Hmm. You always thought you'd be more excited to see a (name-n) in a room.;. Is this what you came to TextWorld for? This... (name-n)?;. You look around you, at all the containers and supporters, doors and objects, and you think to yourself. Why? Why Textworld?
+suffix_price_schtick:. You check the price tag #pricetagexplain#. #pricebad#?! That's ridiculous! #youknow# my #friendtype#, #myfriend#? I'm sure my friend could get you one of those for #pricegood#!;. You check the price tag #pricetagexplain#. #pricebad#?! That's ridiculous! #Iknow# #afriend# who could get you one of those for #pricegood#!;. You look at the price tag #pricetagexplain#. #pricebad#?! Where'd they buy this (name-n), #expensiveplace#?;. You check the price tag #pricetagexplain#. #pricegood#? What a deal! You'll have to ask where they got this!;. Wow, check out the price tag #pricetagexplain#! #pricebad#!;#emptymain#;#emptymainperiod#
+suffix_(r):. Okay, just remember what you're here to do, and everything will go great.;. You try to gain information on your surroundings by using a technique you call 'looking.';. You can barely contain your excitement.;. The room seems oddly familiar, as though it were only superficially different from the other rooms in the building.;. You decide to just list off a complete list of everything you see in the room, because hey, why not?;. I guess you better just go and list everything you see here.;. You start to take note of what's in the room.;. You decide to start listing off everything you see in the room, as if you were in a text adventure.;. The room is well lit.;. You begin to take stock of what's here.;. You begin to take stock of what's in the room.;. You begin looking for stuff.;. Let's see what's in here.;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#
+### Cut for length ###
+suffix:.;. You shudder, but continue examining the room.;. You wonder idly who left that here.;. Now why would someone leave that there?;. There's something strange about this being here, but you can't put your finger on it.;. There's something strange about this thing being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;!;. Hmmm... what else, what else?;. Wow, isn't TextWorld just the best?;. I mean, just wow! Isn't TextWorld just the best?;. You can't wait to tell the folks at home about this!;. Something scurries by right in the corner of your eye. Probably nothing.;. You idly wonder how they came up with the name TextWorld for this place. It's pretty fitting.;. Suddenly, you bump your head on the ceiling, but it's not such a bad bump that it's going to prevent you from looking at objects and even things.;. Now that's what I call TextWorld!;. Classic TextWorld.;. The light flickers for a second, but nothing else happens.;.;.;.;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty30#;#empty31#;#empty32#;#suffix_price_schtick#;#suffix_fulfillment#;#suffix_meta#
+
+###Multi suffixes need to be more flexible than normal ones###
+suffix-multi:.;. You shudder, but continue examining the room.;. You wonder idly who put this stuff here.;. There's something strange about this stuff being here, but you can't put your finger on it.;. There's something strange about this stuff being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;, so why not take a picture, it'll last longer!;. It doesn't get any more TextWorld than this!;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;
+suffix_(s)_mid:.;. You shudder, but continue examining the (name-n).;. You wonder idly who left that here.;. Now why would someone leave that there?;#suffix_meta#;. Why don't you take a picture of it, it'll last longer!;!;. Wow, isn't TextWorld just the best?;. I guess it's true what they say, if you're looking for a (name-n), go to TextWorld.;. What a coincidence, weren't you just thinking about a (name-n)?;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;
+suffix_(s)_end:.;. You shudder, but continue examining the room.;. There's something strange about this being here, but you can't put your finger on it.;. There's something strange about this thing being here, but you don't have time to worry about that now.;. Huh, weird.;, so there's that.;. Hmmm... what else, what else?;. I mean, just wow! Isn't TextWorld just the best?;. You can't wait to tell the folks at home about this!;. Something scurries by right in the corner of your eye. Probably nothing.;. You idly wonder how they came up with the name TextWorld for this place. It's pretty fitting.;. Suddenly, you bump your head on the ceiling, but it's not such a bad bump that it's going to prevent you from looking at objects and even things.;. Wow! Just like in the movies!;. It doesn't get more TextWorld than this!;. Now that's what I call TextWorld!;. Classic TextWorld.;#suffix#;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;
+suffix_(s)_end_angry:. You move on, clearly #upsetwith# TextWorld.;. You move on, clearly #upsetwith# your TextWorld experience.;. Sometimes, just sometimes, TextWorld can just be the worst.;. What's the point of an empty (name-n)?;. Hopefully this doesn't make you too upset.;. You make a mental note to not get your hopes up the next time you see a (name-n) in a room.;. ;. Hopefully, this discovery doesn't ruin your TextWorld experience!;. You swear loudly.;. This always happens!;. This always happens, here in TextWorld!;. Silly (name-n), silly, empty, good for nothing (name-n).;. You think about smashing the (name-n) to bits, throwing the bits #intheblank#, etc, until you get bored.;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n)! oh well.;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;. Aw, and here you were, all excited for there to be things on it!;. Oh! Why couldn't there just be stuff on it?;. Hm. Oh well;. What, you think everything in TextWorld should have stuff on it?;. It would have been so cool if there was stuff on the (name-n).;#emptymainperiod#;#emptymain#;#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;#empty46#;#empty47#;#empty48#;#empty49#;#empty50#;
+#fix expandables in
+#-----------
+smelltype:an #ansmell#;a #asmell#
+ansmell:interesting;awful;intriguing
+asmell:hideous;pungent;sickening;terrible;wretched;lovely;great;fine;
+
+upsetwith:upset with;angry about;infuriated by;depressed by;done caring about;upset by;furious with
+pricetagexplain:that's still affixed to the (name-n);that the (name-n)'s owner still hasn't taken off;that hangs off the (name-n);on the (name-n);glued to the (name-n)
+pricebad:#bignumber# dollars;#bignumber# bucks;#bignumber# big ones
+resourcenumber:10;15;20;25;30;35;40;45;50;55;60;65;70;75;80;85;90;95;100
+bignumber:Thirty;Forty;Fifty;Sixty;Seventy;Eighty;Ninety;A hundred;Two hundred;Three hundred
+Iknow:I know a;I got this;I have a;You know, I know a;You know, I got a;You know what, I've got a
+youknow:You know;Do you know;Did you ever meet;You ever meet
+afriend:person, they work out of #friendplace#,;person;friend;person who works for #friendcompany#;person, their #inlaw# works for #cooljob#,
+inlaw:uncle;aunt;sister-in-law;brother-in-law;cousin;other friend;buddy;pal;roommate;dad;mom;brother;sister;neighbour
+myfriend:they work for #friendcompany#
+cooljob:the store;#friendcompany#;the mayor;the president;the prime minister;the internet
+friendplace:the bank;the big city;city hall
+friendcompany:the government;the post office;the mayor;a company
+friendtype:buddy;pal;friend;good friend;
+pricefriend:half that much;half that;six bucks;practically nothing
+pricegood:#resourcenumber# bucks
+expensiveplace:some kind of expensive place;some kind of expensive store
+intheblank:in the dump;in a fire;into a pit;into the garbage
+#General Expandables
+#------------------
+
+canshould:can;should;should be able to;may
+looks:seems to be;looks;seems;appears
+here_alt:here;in the room;nearby;close by;in the corner;right there by you
+here_alt_u:Here;In the room;Nearby;Close by;In the corner;Right there by you
+how_see:You #you_what#;You can #you_what#
+how_see_u:you #you_what#;you can #you_what#
+there_what:is;seems to be
+you_what:see;make out
+
+
+emptymainperiod:#emptymain#
+emptymain:#empty1#;#empty2#;#empty3#;#empty4#;#empty5#;#empty6#;#empty7#;#empty8#;#empty9#;#empty10#;#empty11#;#empty12#;#empty13#;#empty14#;#empty15#;#empty16#;#empty17#;#empty18#;#empty19#;#empty20#;#empty21#;#empty22#;#empty23#;#empty24#;#empty25#;#empty26#;#empty27#;#empty28#;#empty29#;#empty30#;#empty31#;#empty32#;#empty33#;#empty34#;#empty35#;#empty36#;#empty37#;#empty38#;#empty39#;#empty40#;#empty41#;#empty42#;#empty43#;#empty44#;#empty45#;#empty46#;#empty47#;#empty48#;#empty49#;#empty50#;#empty51#;#empty52#;#empty53#;#empty54#;#empty55#;#empty56#;#empty57#;#empty58#;#empty59#;#empty60#;#empty61#;#empty62#;#empty63#
+empty1:.;
+empty2:.;
+empty3:.;
+empty4:.;
+empty5:.;
+empty6:.;
+empty7:.;
+empty8:.;
+empty9:.;
+empty10:.;
+empty11:.;
+empty12:.;
+empty13:.;
+empty14:.;
+empty15:.;
+empty16:.;
+empty17:.;
+empty18:.;
+empty19:.;
+empty20:.;
+empty21:.;
+empty22:.;
+empty23:.;
+empty24:.;
+empty25:.;
+empty26:.;
+empty27:.;
+empty28:.;
+empty29:.;
+empty30:.;
+empty31:.;
+empty32:.;
+empty33:.;
+empty34:.;
+empty35:.;
+empty36:.;
+empty37:.;
+empty38:.;
+empty39:.;
+empty40:.;
+empty41:.;
+empty42:.;
+empty43:.;
+empty44:.;
+empty45:.;
+empty46:.;
+empty47:.;
+empty48:.;
+empty49:.;
+empty50:.;
+empty51:.;
+empty52:.;
+empty53:.;
+empty54:.;
+empty55:.;
+empty56:.;
+empty57:.;
+empty58:.;
+empty59:.;
+empty60:.;
+empty61:.;
+empty62:.;
+empty63:.;

--- a/textworld/generator/vtypes.py
+++ b/textworld/generator/vtypes.py
@@ -195,6 +195,9 @@ class VariableTypeTree:
 
     def descendants(self, vtype):
         """Given a variable type, return all possible descendants."""
+        if vtype not in self.variables_types:
+            return []
+
         descendants = []
         for child_type in self[vtype].children:
             descendants.append(child_type)


### PR DESCRIPTION
Challenges shipped with TextWorld depend on the default KnowledgeBase version also shipped with TextWorld. Therefore, any breaking changes to the default KnowledgeBase might cause game generation for the different challenges to break as well. This PR makes sure we keep a snapshot of the KnowledgeBase for each challenge.

Breaking changes: when generating games for a particular TextWorld challenge, you can't change the grammar option anymore.