### PR TITLE
ENH: use tw-extract to extract walkthroughs and commands

### DIFF
--- a/scripts/tw-extract
+++ b/scripts/tw-extract
@@ -44,6 +44,13 @@ def parse_args():
     entities_parser.add_argument("--output", default="entities.txt",
                                  help="Output file containing all entity names (.txt). Default: %(default)s")
 
+    walkthrough_parser = subparsers.add_parser("walkthroughs", parents=[general_parser],
+                                               help='Extract walkthroughs.')
+    walkthrough_parser.add_argument("games", metavar="game", nargs="+",
+                                    help="List of TextWorld games (.ulx|.json).")
+    walkthrough_parser.add_argument("--output", default="walkthroughs.txt",
+                                    help="Output file containing all walkthroughs (.txt). Default: %(default)s")
+
     return parser.parse_args(), parser
 
 
@@ -66,6 +73,8 @@ def main():
             game = Game.load(jsonfile)
             infos |= set(game.objects_names)
 
+        infos = sorted(infos)
+
     elif args.subcommand == "vocab":
         units = ["word", "words"]
         infos = extract_vocab_from_gamefiles(args.games)
@@ -78,8 +87,13 @@ def main():
             # Strip out all non-alphabetic characters
             text = re.sub(r"[^a-z0-9\-_ ']", " ", text.lower())
             infos |= set(word.strip("-'_") for word in text.split())
+        infos = sorted(infos)
 
-    infos = sorted(infos)
+    elif args.subcommand == "walkthroughs":
+        units = ["walkthrough", "walkthroughs"]
+        games_iter = (Game.load(os.path.splitext(gamefile)[0] + ".json") for gamefile in args.games)
+        walkthroughs = [" > ".join(game.metadata.get("walkthrough", [])) for game in games_iter]
+        infos = walkthroughs
 
     unit = units[1] if len(infos) > 1 else units[0]
     if args.verbose:

--- a/scripts/tw-extract
+++ b/scripts/tw-extract
@@ -6,6 +6,7 @@
 import os
 import re
 import sys
+import itertools
 import pprint
 import argparse
 
@@ -51,6 +52,13 @@ def parse_args():
     walkthrough_parser.add_argument("--output", default="walkthroughs.txt",
                                     help="Output file containing all walkthroughs (.txt). Default: %(default)s")
 
+    commands_parser = subparsers.add_parser("commands", parents=[general_parser],
+                                            help='Extract all possible commands.')
+    commands_parser.add_argument("games", metavar="game", nargs="+",
+                                 help="List of TextWorld games (.ulx|.json).")
+    commands_parser.add_argument("--output", default="commands.txt",
+                                 help="Output file containing all commands (.txt). Default: %(default)s")
+
     return parser.parse_args(), parser
 
 
@@ -87,6 +95,7 @@ def main():
             # Strip out all non-alphabetic characters
             text = re.sub(r"[^a-z0-9\-_ ']", " ", text.lower())
             infos |= set(word.strip("-'_") for word in text.split())
+
         infos = sorted(infos)
 
     elif args.subcommand == "walkthroughs":
@@ -94,6 +103,32 @@ def main():
         games_iter = (Game.load(os.path.splitext(gamefile)[0] + ".json") for gamefile in args.games)
         walkthroughs = [" > ".join(game.metadata.get("walkthrough", [])) for game in games_iter]
         infos = walkthroughs
+
+    elif args.subcommand == "commands":
+        units = ["command", "commands"]
+        infos = set()
+        for gamefile in args.games:
+            game = Game.load(os.path.splitext(gamefile)[0] + ".json")
+
+            # Build objects_per_types mapping.
+            objects_per_type = {t: [] for t in game.objects_types}
+            for name, t in game.objects_names_and_types:
+                objects_per_type[t].append(name)
+
+            commands = []
+            regex = re.compile(r"{{({})}}".format("|".join(game.objects_types)))
+            for template in game.command_templates:
+                placeholders = regex.findall(template)
+
+                iter_candidates = itertools.product(*[objects_per_type[t] for t in placeholders])
+                for candidates in iter_candidates:
+                    commands.append(template)
+                    for placeholder, candidate in zip(placeholders, candidates):
+                        commands[-1] = commands[-1].replace("{" + placeholder + "}", candidate, 1)
+
+            infos |= set(commands)
+
+        infos = sorted(infos)
 
     unit = units[1] if len(infos) > 1 else units[0]
     if args.verbose:

--- a/tests/test_tw-extract.py
+++ b/tests/test_tw-extract.py
@@ -73,3 +73,17 @@ class TestTwExtract(unittest.TestCase):
         assert walkthrough1 == walkthroughs[0].strip()
         assert walkthrough2 == walkthroughs[1].strip()
         assert "Found {}".format(2) in stdout
+
+    def test_extract_commands(self):
+        outfile = pjoin(self.tmpdir, "commands.txt")
+        command = ["tw-extract", "commands", self.game_file1, self.game_file2, "--output", outfile]
+        stdout = check_output(command).decode()
+        assert os.path.isfile(outfile)
+        assert "Found" in stdout
+
+        content = open(outfile).read()
+        for name in self.game1.entity_names + self.game2.entity_names:
+            assert name in content
+
+        for verb in self.game1.verbs + self.game2.verbs:
+            assert verb in content

--- a/tests/test_tw-extract.py
+++ b/tests/test_tw-extract.py
@@ -3,57 +3,73 @@
 
 import re
 import os
+import glob
+import shutil
+import unittest
+import tempfile
 from os.path import join as pjoin
 from subprocess import check_output
 
 import textworld
-from textworld.utils import make_temp_directory
 
 
-def test_extract_vocab():
-    with make_temp_directory(prefix="test_extract_vocab") as tmpdir:
+class TestTwExtract(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = pjoin(tempfile.mkdtemp(prefix="test_tw_extract"), "")
         options = textworld.GameOptions()
-        options.path = tmpdir
+        options.path = cls.tmpdir
         options.nb_rooms = 5
         options.nb_objects = 10
         options.quest_length = 5
         options.quest_breadth = 2
         options.seeds = 1234
-        game_file1, _ = textworld.make(options)
+        cls.game_file1, cls.game1 = textworld.make(options)
         options.seeds = 12345
-        game_file2, _ = textworld.make(options)
+        options.file_ext = ".z8"
+        cls.game_file2, cls.game2 = textworld.make(options)
 
-        outfile = pjoin(tmpdir, "vocab.txt")
-        command = ["tw-extract", "vocab", game_file1, game_file2, "--output", outfile]
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir)
+
+    def tearDown(self):
+        for f in glob.glob(pjoin(self.tmpdir, "*.txt")):
+            os.remove(f)
+
+    def test_extract_vocab(self):
+        outfile = pjoin(self.tmpdir, "vocab.txt")
+        command = ["tw-extract", "vocab", self.game_file1, self.game_file2, "--output", outfile]
         stdout = check_output(command).decode()
         assert os.path.isfile(outfile)
         nb_words = len(open(outfile).readlines())
         assert "Found {}".format(nb_words) in stdout
 
-
-def test_extract_vocab_theme():
-    with make_temp_directory(prefix="test_extract_vocab_theme") as tmpdir:
-        outfile = pjoin(tmpdir, "vocab.txt")
+    def test_extract_vocab_theme(self):
+        outfile = pjoin(self.tmpdir, "vocab.txt")
         command = ["tw-extract", "vocab", "--theme", "house", "--output", outfile]
         stdout = check_output(command).decode()
         assert os.path.isfile(outfile)
         assert int(re.findall(r"Found (\d+)", stdout)[0]) > 0
 
-
-def test_extract_entities():
-    with make_temp_directory(prefix="test_extract_entities") as tmpdir:
-        options = textworld.GameOptions()
-        options.path = tmpdir
-        options.nb_rooms = 5
-        options.nb_objects = 10
-        options.quest_length = 5
-        options.quest_breadth = 2
-        options.seeds = 1234
-        game_file, _ = textworld.make(options)
-
-        outfile = pjoin(tmpdir, "entities.txt")
-        command = ["tw-extract", "entities", game_file, "--output", outfile]
+    def test_extract_entities(self):
+        outfile = pjoin(self.tmpdir, "entities.txt")
+        command = ["tw-extract", "entities", self.game_file1, "--output", outfile]
         stdout = check_output(command).decode()
         assert os.path.isfile(outfile)
         nb_entities = len(open(outfile).readlines())
         assert "Found {}".format(nb_entities) in stdout
+
+    def test_extract_walkthroughs(self):
+        outfile = pjoin(self.tmpdir, "walkthroughs.txt")
+        command = ["tw-extract", "walkthroughs", self.game_file1, self.game_file2, "--output", outfile]
+        stdout = check_output(command).decode()
+        assert os.path.isfile(outfile)
+        walkthrough1 = " > ".join(self.game1.metadata["walkthrough"])
+        walkthrough2 = " > ".join(self.game2.metadata["walkthrough"])
+        walkthroughs = open(outfile).readlines()
+        assert len(walkthroughs) == 2
+        assert walkthrough1 == walkthroughs[0].strip()
+        assert walkthrough2 == walkthroughs[1].strip()
+        assert "Found {}".format(2) in stdout


### PR DESCRIPTION
This PR adds the `walkthroughs` subcommand to `tw-extract` to extract walkthroughs from a list of games.

This PR adds the `commands` subcommand to `tw-extract` to extract commands from a list of games. Here "commands" do not mean admissible commands, it is more like a superset of the actual action space.