### PR TITLE
Prevent overwriting the name of matching entities (e.g. container-key).

### DIFF
--- a/textworld/generator/text_generation.py
+++ b/textworld/generator/text_generation.py
@@ -22,6 +22,9 @@ class CountOrderedDict(OrderedDict):
 
 
 def assign_new_matching_names(obj1_infos, obj2_infos, grammar, exclude):
+    if obj1_infos.name is not None or obj2_infos.name is not None:
+        return False  # One of the objects has already a name assigned to it.
+
     tag = "#({}<->{})_match#".format(obj1_infos.type, obj2_infos.type)
     if not grammar.has_tag(tag):
         return False

--- a/textworld/logic/tests/test_types.py
+++ b/textworld/logic/tests/test_types.py
@@ -75,11 +75,11 @@ def test_multi_closure():
     pairs = list(hier.multi_ancestors((d, d)))
 
     expected = {
-                (b, d), (c, d), (d, b), (d, c),
-        (a, d), (b, b), (b, c), (c, b), (c, c), (d, a),
+                (b, d), (c, d), (d, b), (d, c),  # noqa: E126
+        (a, d), (b, b), (b, c), (c, b), (c, c), (d, a),  # noqa: E131
                 (a, b), (a, c), (b, a), (c, a),
-                            (a, a),
-    }  # noqa: E131
+                            (a, a),  # noqa: E131
+    }
 
     assert len(pairs) == len(expected)
     assert set(pairs) == expected
@@ -87,11 +87,11 @@ def test_multi_closure():
     pairs = list(hier.multi_descendants((a, a)))
 
     expected = {
-                (a, b), (a, c), (b, a), (c, a),
-        (a, d), (b, b), (b, c), (c, b), (c, c), (d, a),
+                (a, b), (a, c), (b, a), (c, a),  # noqa: E126
+        (a, d), (b, b), (b, c), (c, b), (c, c), (d, a),  # noqa: E131
                 (b, d), (c, d), (d, b), (d, c),
-                            (d, d),
-    }  # noqa: E131
+                            (d, d),  # noqa: E131
+    }
 
     assert len(pairs) == len(expected)
     assert set(pairs) == expected


### PR DESCRIPTION
Closes issue #236 

This PR prevents overwriting the name of already named entities even if those are "matching" entities (e.g. key <-> container, key <-> door).