### PR TITLE
Fix bugs and small refactoring

### DIFF
--- a/textworld/envs/zmachine/jericho.py
+++ b/textworld/envs/zmachine/jericho.py
@@ -117,6 +117,7 @@ class JerichoEnv(textworld.Environment):
 
         if self._jericho:
             env._jericho = self._jericho.copy()
+            env._reset = True
 
         # Copy core Environment's attributes.
         env.state = self.state.copy()

--- a/textworld/envs/zmachine/tests/test_jericho.py
+++ b/textworld/envs/zmachine/tests/test_jericho.py
@@ -211,6 +211,15 @@ class TestJerichoEnv(unittest.TestCase):
         assert_jericho_state_equals(bkp._jericho.get_state(), jericho_state)
         assert bkp.state == state
 
+        # Bring the copied env up-to-date by issuing the same commands.
+        walkthrough = self.game.metadata["walkthrough"]
+        for command in walkthrough[:len(walkthrough) // 2]:
+            game_state, score, done = bkp.step(command)
+
+        # And compare the states.
+        assert_jericho_state_equals(bkp._jericho.get_state(),
+                                    env._jericho.get_state())
+
         bkp = env.copy()
         assert bkp._jericho != env._jericho  # Not the same object.
         assert_jericho_state_equals(bkp._jericho.get_state(),

--- a/textworld/generator/game.py
+++ b/textworld/generator/game.py
@@ -8,6 +8,7 @@ import textwrap
 
 from typing import List, Dict, Optional, Mapping, Any, Iterable, Union, Tuple
 from collections import OrderedDict
+from functools import partial
 
 from numpy.random import RandomState
 
@@ -416,7 +417,7 @@ class Game:
         """ Changes the grammar used and regenerate all text. """
 
         self.grammar = grammar
-        _gen_commands = gen_commands_from_actions
+        _gen_commands = partial(gen_commands_from_actions, kb=self.kb)
         if self.grammar:
             from textworld.generator.inform7 import Inform7Game
             from textworld.generator.text_generation import generate_text_from_grammar

--- a/textworld/generator/game.py
+++ b/textworld/generator/game.py
@@ -669,11 +669,11 @@ class ActionDependencyTree(DependencyTree):
     def remove(self, action: Action) -> Tuple[bool, Optional[Action]]:
         changed = super().remove(action)
 
-        if self.empty:
-            return changed, None
-
         # The last action might have impacted one of the subquests.
         reverse_action = self._kb.get_reverse_action(action)
+        if self.empty:
+            return changed, reverse_action
+
         if reverse_action is not None:
             changed = self.push(reverse_action)
         elif self.push(action.inverse()):
@@ -692,14 +692,15 @@ class ActionDependencyTree(DependencyTree):
         """
         tree = self.copy()  # Make a copy of the tree to work on.
         last_reverse_action = None
+        changed = False
         while len(tree.roots) > 0:
             # Use 'sort' to try leaves that doesn't affect the others first.
             for leaf in sorted(tree.leaves_elements):
-                if leaf.action != last_reverse_action:
+                if leaf.action != last_reverse_action or not changed:
                     break  # Choose an action that avoids cycles.
 
             yield leaf.action
-            _, last_reverse_action = tree.remove(leaf.action)
+            changed, last_reverse_action = tree.remove(leaf.action)
 
             # Prune empty roots
             for root in list(tree.roots):
@@ -829,7 +830,7 @@ class EventProgression:
             return None
 
         compressed = False
-        policy = _find_shorter_policy(self._policy)
+        policy = _find_shorter_policy(tuple(a for a in self._tree.flatten()))
         while policy is not None:
             compressed = True
             self._policy = policy

--- a/textworld/generator/maker.py
+++ b/textworld/generator/maker.py
@@ -801,7 +801,7 @@ class GameMaker:
         options = self.options.grammar.copy()
         options.names_to_exclude += list(used_names)
 
-        grammar = Grammar(options, rng=np.random.RandomState(self.options.seeds["grammar"]))
+        grammar = Grammar(options, rng=np.random.RandomState(self.options.seeds["grammar"]), kb=self.options.kb)
         game.change_grammar(grammar)
         game.metadata["desc"] = "Generated with textworld.GameMaker."
 

--- a/textworld/generator/text_grammar.py
+++ b/textworld/generator/text_grammar.py
@@ -135,7 +135,8 @@ class Grammar:
 
     _cache = {}
 
-    def __init__(self, options: Union[GrammarOptions, Mapping[str, Any]] = {}, rng: Optional[RandomState] = None):
+    def __init__(self, options: Union[GrammarOptions, Mapping[str, Any]] = {}, rng: Optional[RandomState] = None,
+                 kb: Optional[KnowledgeBase] = None):
         """
         Arguments:
             options:
@@ -162,9 +163,14 @@ class Grammar:
         # Load the object names file
         path = pjoin(KnowledgeBase.default().text_grammars_path, glob.escape(self.theme) + "*.twg")
         files = glob.glob(path)
+        if kb is not None:
+            path = pjoin(kb.text_grammars_path, glob.escape(self.theme) + "*.twg")
+            files += glob.glob(path)
+
         if len(files) == 0:
             raise MissingTextGrammar(path)
 
+        self.grammar_files = files
         for filename in files:
             self._parse(filename)
 


### PR DESCRIPTION
This PR:
- fixes an issue with copying `JerichoEnv`.
- allows proving a KB object to `TextGrammar` constructor.
- improves the flexibility of `KnowledgeBase.load(logic_path=..., grammar_path=)`