### PR TITLE
FIX: handle type inheritance in 'tw-extract commands'.

### DIFF
--- a/scripts/tw-extract
+++ b/scripts/tw-extract
@@ -125,6 +125,8 @@ def main():
             objects_per_type = {t: [] for t in game.objects_types}
             for name, t in game.objects_names_and_types:
                 objects_per_type[t].append(name)
+                for ancestor in game.kb.types.get_ancestors(t):
+                    objects_per_type[ancestor].append(name)
 
             commands = []
             regex = re.compile(r"{{({})}}".format("|".join(game.objects_types)))

--- a/tests/test_tw-extract.py
+++ b/tests/test_tw-extract.py
@@ -99,3 +99,7 @@ class TestTwExtract(unittest.TestCase):
 
         for verb in self.game1.verbs + self.game2.verbs:
             assert verb in content
+
+        # Check inheritance of command templates, e.g., 'examine {t}' -> ['examine {o}', 'examine {k}', 'examine {f}']
+        for obj_name in self.game1.objects_names:
+            assert "examine {}".format(obj_name) in content


### PR DESCRIPTION
Fixes #268 
This PR fixes an issue with `tw-extract commands ...` where type inheritance in command templates was not properly handled.