### PR TITLE
Allow option to provide list of seeds in BatchEnv

### DIFF
--- a/textworld/envs/batch/batch_env.py
+++ b/textworld/envs/batch/batch_env.py
@@ -116,9 +116,12 @@ class AsyncBatchEnv(Environment):
             env.result()
 
     def seed(self, seed=None):
-        # Use a different seed for each env to decorrelate batch examples.
-        rng = np.random.RandomState(seed)
-        seeds = list(rng.randint(65635, size=self.batch_size))
+        seeds = seed
+        if seeds is None or isinstance(seeds, int):
+            # Use a different seed for each env to decorrelate batch examples.
+            rng = np.random.RandomState(seeds)
+            seeds = list(rng.randint(65635, size=self.batch_size))
+
         for env, seed in zip(self.envs, seeds):
             env.call_sync("seed", seed)
 
@@ -209,9 +212,12 @@ class SyncBatchEnv(Environment):
             env.load(game_file)
 
     def seed(self, seed=None):
-        # Use a different seed for each env to decorrelate batch examples.
-        rng = np.random.RandomState(seed)
-        seeds = list(rng.randint(65635, size=self.batch_size))
+        seeds = seed
+        if seeds is None or isinstance(seeds, int):
+            # Use a different seed for each env to decorrelate batch examples.
+            rng = np.random.RandomState(seeds)
+            seeds = list(rng.randint(65635, size=self.batch_size))
+
         for env, seed in zip(self.envs, seeds):
             env.seed(seed)
 


### PR DESCRIPTION
This PR adds the option for providing a list of seeds to initialize each environment of an `AsyncBatchEnv` or `SyncBatchEnv`.