### PR TITLE
CI: Remove MacOS 10.14 image.

### DIFF
--- a/.azure/pipelines/prerelease.yml
+++ b/.azure/pipelines/prerelease.yml
@@ -42,14 +42,13 @@ stages:
       pythonVersions: [ '3.7' ]
   - template: linux-template.yml
     parameters:
-      vmImages: [ 'ubuntu-20.04' ]
-      pythonVersions: [ '3.7', '3.8', '3.9']
-  - template: macos-template.yml
-    parameters:
-      vmImages: [ 'macOS-10.14' ]
-      pythonVersions: [ '3.6' ]
+      vmImages: [ 'ubuntu-latest' ]
+      pythonVersions: [ '3.8' ]
   - template: macos-template.yml
     parameters:
       vmImages: [ 'macOS-10.15' ]
       pythonVersions: [ '3.7' ]
-      # pythonVersions: [ '3.8' ]  # For some reasons, chromedriver is failing.
+  - template: macos-template.yml
+    parameters:
+      vmImages: [ 'macOS-latest' ]
+      pythonVersions: [ '3.9' ]

--- a/.azure/pipelines/tests.yml
+++ b/.azure/pipelines/tests.yml
@@ -11,17 +11,16 @@ stages:
   - template: linux-template.yml
     parameters:
       vmImages: [ 'ubuntu-18.04' ]
-      pythonVersions: [ '3.7', '3.8' ]
+      pythonVersions: [ '3.7' ]
   - template: linux-template.yml
     parameters:
-      vmImages: [ 'ubuntu-20.04' ]
-      pythonVersions: [ '3.7', '3.8' ]
-  - template: macos-template.yml
-    parameters:
-      vmImages: [ 'macOS-10.14' ]
-      pythonVersions: [ '3.6' ]
+      vmImages: [ 'ubuntu-latest' ]
+      pythonVersions: [ '3.8' ]
   - template: macos-template.yml
     parameters:
       vmImages: [ 'macOS-10.15' ]
       pythonVersions: [ '3.7' ]
-      # pythonVersions: [ '3.8' ]  # For some reasons, chromedriver is failing.
+  - template: macos-template.yml
+    parameters:
+      vmImages: [ 'macOS-latest' ]
+      pythonVersions: [ '3.9' ]

--- a/textworld/envs/batch/batch_env.py
+++ b/textworld/envs/batch/batch_env.py
@@ -38,6 +38,8 @@ def _child(env_fn, parent_pipe, pipe):
                 result = getattr(obj, attrs[-1])
             elif command[0] == "hasattr":
                 result = hasattr(obj, attrs[-1])
+            elif command[0] == "close":
+                break
 
             pipe.send(result)
 
@@ -189,6 +191,9 @@ class AsyncBatchEnv(Environment):
         # Join
         for env in self.envs:
             env.result()
+
+    def __del__(self):
+        self.close()
 
 
 class SyncBatchEnv(Environment):

--- a/textworld/envs/batch/tests/test_batch_env.py
+++ b/textworld/envs/batch/tests/test_batch_env.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import gym
 
 import textworld
@@ -34,13 +36,12 @@ def test_batch_env():
         env.reset()
         # env.close()
         del env
-        print("OKAY")
 
 
 def test_seed():
     batch_size = 4
     env_options = EnvInfos(inventory=True, description=True, admissible_commands=True)
-    env_fns = [lambda: JerichoEnv(env_options) for _ in range(batch_size)]
+    env_fns = [partial(JerichoEnv, env_options) for _ in range(batch_size)]
 
     env = SyncBatchEnv(env_fns)
     seeds = env.seed(1234)

--- a/textworld/render/serve.py
+++ b/textworld/render/serve.py
@@ -191,6 +191,7 @@ class VisualizationService:
         thread = Thread(target=wait_task, name='waiting_on_parent_exit')
         thread.start()
 
+        self.parent_conn.recv()  # Wait until server is ready.
         print("Viewer started at http://localhost:{}.".format(self.port))
         if self.open_automatically:
             check_modules(["webbrowser"], missing_modules)
@@ -262,6 +263,7 @@ class Server:
         :param conn: child connection from multiprocessing.Pipe.
         :param results: thread-safe queue for results.
         """
+        conn.send("Ready!")  # Tell the main thread the server is ready.
         while True:
             game_state = conn.recv()
             results.put(game_state)


### PR DESCRIPTION
This PR removes the deprecated CI for MacOS 10.14 and replaces it with MacOS-latest (i.e., MacOS 11).
This PR also fixes a couple of concurrency issues in the VisualizationServive and AsyncBatchEnv. Starting with Python 3.8 multiprocessing uses "spawn" context rather than "fork" on MacOS. The "spawn" context being slower to start a new process, it revealed those concurrency issues TextWorld had.