### PR TITLE
Added stricter state checking for inform7 backend

### DIFF
--- a/textworld/envs/wrappers/tw_inform7.py
+++ b/textworld/envs/wrappers/tw_inform7.py
@@ -135,7 +135,10 @@ class Inform7Data(textworld.core.Wrapper):
 
         for info in ["score", "moves"]:
             if self.state[info] is not None and type(self.state[info]) is not int:
-                self.state[info] = int(self.state[info].strip())
+                try:
+                    self.state[info] = int(self.state[info].strip())
+                except:
+                    self.state[info] = int(self.state[info].strip().split("\n")[0])
 
         self.state["won"] = '*** The End ***' in self.state["feedback"]
         self.state["lost"] = '*** You lost! ***' in self.state["feedback"]


### PR DESCRIPTION
Adds a stronger check when parsing the "score" and "moves" fields for info in the inform7 backend. 

https://github.com/pearls-lab/TextWorld/blob/c812d677dafc0728e49ab95cb52a35c0a1876c0c/textworld/envs/wrappers/tw_inform7.py#L138

This is largely needed for using Textworld to train Large Language Models, as it appears that some outputs from the models can cause the inform7 backend to mistake malformed outputs as part of its underlying state tracking, thus leading to an error here.

The try catch here isn't a particularly elegant solution but is robust enough that I haven't had the need to modify it, nor encountered this error again, across a large number of RL training runs.